### PR TITLE
feat: Add the build id as output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   env-passthrough:
     description: 'Comma separated list of environment variables to send to CodeBuild'
     required: false
+outputs:
+  aws-build-id:
+    description: 'The AWS CodeBuild Build ID for this build.'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/code-build.js
+++ b/code-build.js
@@ -30,13 +30,7 @@ async function _buildProject(sdk, params) {
   const start = await sdk.codeBuild.startBuild(params).promise();
 
   // Wait for the build to "complete"
-  const build = await waitForBuildEndTime(sdk, start.build);
-
-  // Signal the outcome
-  assert(
-    build.buildStatus === "SUCCEEDED",
-    `Build status: ${build.buildStatus}`
-  );
+  return waitForBuildEndTime(sdk, start.build);
 }
 
 async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 const core = require("@actions/core");
 const { buildProject } = require("./code-build");
+const assert = require("assert");
 
 /* istanbul ignore next */
 if (require.main === module) {
@@ -13,7 +14,14 @@ module.exports = run;
 
 async function run() {
   try {
-    await buildProject();
+    const build = await buildProject();
+    core.setOutput("aws-build-id", build.id);
+
+    // Signal the outcome
+    assert(
+      build.buildStatus === "SUCCEEDED",
+      `Build status: ${build.buildStatus}`
+    );
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
Downstream actions may want to interact with this build.
Output the build id so that any needed information can be accessed.

related: #6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

