### PR TITLE
fix: add log entries before and after CodeBuild activity to differentiate GitHub log activity from CodeBuild log activity

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -16,16 +16,14 @@ module.exports = {
   logName
 };
 
-async function runBuild() {
+function runBuild() {
   // get a codeBuild instance from the SDK
   const sdk = buildSdk();
 
   // Get input options for startBuild
   const params = inputs2Parameters(githubInputs());
 
-  console.log("*****STARTING CODEBUILD*****");
-  await build(sdk, params);
-  console.log("*****CODEBUILD COMPLETE*****");
+  return build(sdk, params);
 }
 
 async function build(sdk, params) {

--- a/code-build.js
+++ b/code-build.js
@@ -15,14 +15,16 @@ module.exports = {
   logName
 };
 
-function buildProject() {
+async function buildProject() {
   // get a codeBuild instance from the SDK
   const sdk = buildSdk();
 
   // Get input options for startBuild
   const params = inputs2Parameters();
 
-  return _buildProject(sdk, params);
+  console.log("*****STARTING CODEBUILD*****");
+  await _buildProject(sdk, params);
+  console.log("*****CODEBUILD COMPLETE*****");
 }
 
 async function _buildProject(sdk, params) {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ if (require.main === module) {
 module.exports = run;
 
 async function run() {
+  console.log("*****STARTING CODEBUILD*****");
   try {
     const build = await runBuild();
     core.setOutput("aws-build-id", build.id);
@@ -24,5 +25,7 @@ async function run() {
     );
   } catch (error) {
     core.setFailed(error.message);
+  } finally {
+    console.log("*****CODEBUILD COMPLETE*****");
   }
 }


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

