### PR TITLE
feat: rename input from env-passthrough to env-vars-for-codebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The only required input is `project-name`.
    that CodeBuild requires.
    By default, the action uses the buildspec file location
    that you configured in the CodeBuild project.
-1. **env-passthrough** (optional) :
+1. **env-vars-for-codebuild** (optional) :
    A comma-separated list of the names of environment variables
    that the action passes from GitHub Actions to CodeBuild.
 
@@ -154,7 +154,7 @@ this will overwrite them.
   with:
     project-name: CodeBuildProjectName
     buildspec-override: path/to/buildspec.yaml
-    env-passthrough: |
+    env-vars-for-codebuild: |
       custom,
       requester,
       event-name

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   buildspec-override:
     description: 'Buildspec Override'
     required: false
-  env-passthrough:
+  env-vars-for-codebuild:
     description: 'Comma separated list of environment variables to send to CodeBuild'
     required: false
 outputs:

--- a/code-build.js
+++ b/code-build.js
@@ -79,7 +79,7 @@ function githubInputs() {
     core.getInput("buildspec-override", { required: false }) || undefined;
 
   const envPassthrough = core
-    .getInput("env-passthrough", { required: false })
+    .getInput("env-vars-for-codebuild", { required: false })
     .split(",")
     .map(i => i.trim())
     .filter(i => i !== "");

--- a/local.js
+++ b/local.js
@@ -20,7 +20,7 @@ const { projectName, buildspecOverride, envPassthrough, remote } = yargs
     describe: "Path to buildspec file",
     type: "string"
   })
-  .option("env-passthrough", {
+  .option("env-vars-for-codebuild", {
     alias: "e",
     describe: "List of environment variables to send to CodeBuild",
     type: "array"

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -83,7 +83,7 @@ describe("githubInputs", () => {
     process.env[`GITHUB_REPOSITORY`] = repoInfo;
     process.env[`GITHUB_SHA`] = sha;
 
-    process.env[`INPUT_ENV-PASSTHROUGH`] = `one, two 
+    process.env[`INPUT_ENV-VARS-FOR-CODEBUILD`] = `one, two 
     , three,
     four    `;
 
@@ -177,7 +177,7 @@ describe("inputs2Parameters", () => {
     process.env[`GITHUB_REPOSITORY`] = repoInfo;
     process.env[`GITHUB_SHA`] = sha;
 
-    process.env[`INPUT_ENV-PASSTHROUGH`] = `one, two 
+    process.env[`INPUT_ENV-VARS-FOR-CODEBUILD`] = `one, two 
     , three,
     four    `;
 

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -76,7 +76,7 @@ describe("githubInputs", () => {
     expect(() => githubInputs()).to.throw();
   });
 
-  it("can process env-passthrough", () => {
+  it("can process env-vars-for-codebuild", () => {
     // This is how GITHUB injects its input values.
     // It would be nice if there was an easy way to test this...
     process.env[`INPUT_PROJECT-NAME`] = projectName;
@@ -170,7 +170,7 @@ describe("inputs2Parameters", () => {
       .and.to.equal("PLAINTEXT");
   });
 
-  it("can process env-passthrough", () => {
+  it("can process env-vars-for-codebuild", () => {
     // This is how GITHUB injects its input values.
     // It would be nice if there was an easy way to test this...
     process.env[`INPUT_PROJECT-NAME`] = projectName;


### PR DESCRIPTION
*Issue #, if available:*
fixes: #17

*Description of changes:*

rename input from env-passthrough to env-vars-for-codebuild

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

