### PR TITLE
chore: Bump version to 1.0.0 and add readme note about secrets access

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ you need to provide AWS credentials.
 We recommend using [aws-actions/configure-aws-credentials]
 to configure your credentials for a job.
 
+**NOTE:
+GitHub Secrets are not passed to the runner when a workflow is triggered from a forked repository.
+This means that you cannot use this action directly in a workflow
+that is triggered by pull requests from a fork.
+See the [GitHub Secrets docs][github secrets access] for more information.**
+
 The credentials that you provide need to have the following permissions:
 
 - `codebuild:StartBuild`
@@ -246,4 +252,5 @@ see LICENSE and NOTICE for more information.
 [github environment variables]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables
 [github actions job runners]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
 [github workflow syntax]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+[github secrets access]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#using-encrypted-secrets-in-a-workflow
 [aws-actions/configure-aws-credentials]: https://github.com/aws-actions/configure-aws-credentials

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ the only CodeBuild Run input you need to provide is the project name.
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     aws-region: us-east-2
 - name: Run CodeBuild
-  uses: aws-actions/aws-codebuild-run-project@v1
+  uses: aws-actions/aws-codebuild-run-project@v1.0.0
   with:
     project-name: CodeBuildProjectName
 ```
@@ -156,7 +156,7 @@ this will overwrite them.
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     aws-region: us-east-2
 - name: Run CodeBuild
-  uses: aws-actions/aws-codebuild-run-project@v1
+  uses: aws-actions/aws-codebuild-run-project@v1.0.0
   with:
     project-name: CodeBuildProjectName
     buildspec-override: path/to/buildspec.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-actions/codebuild-run-build",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Execute CodeBuild::startBuild for the current repo.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
*Description of changes:*

Bump version to 1.0.0 and add readme note about secrets access.
I also re-ran `npm run package`, but it looks like the version bump didn't change anything for that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

