### PR TITLE
fix: CloudWatchLog line endings

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -56,7 +56,10 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
   const { nextForwardToken, events = [] } = cloudWatch;
 
   // stdout the CloudWatchLog (everyone likes progress...)
-  events.forEach(({ message }) => console.log(message));
+  // CloudWatchLogs have line endings.
+  // I trim and then log each line
+  // to ensure that the line ending is OS specific.
+  events.forEach(({ message }) => console.log(message.trimEnd()));
 
   // We did it! We can stop looking!
   if (current.endTime && !events.length) return current;


### PR DESCRIPTION
CloudWatchLog adds a line ending to each line.
`console.log` also adds a line ending.
I only need one.
I trimEnd and then `console.log` to ensure that the line ending is OS specific.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

