### PR TITLE
Issue #28: Increase sleep timeout to prevent api rate limiting

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -35,7 +35,12 @@ async function build(sdk, params) {
 }
 
 async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
-  const { codeBuild, cloudWatchLogs, wait = 1000 * 30 } = sdk;
+  const {
+    codeBuild,
+    cloudWatchLogs,
+    wait = 1000 * 30,
+    backOff = 1000 * 15
+  } = sdk;
 
   // Get the CloudWatchLog info
   const startFromHead = true;
@@ -67,7 +72,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
       errMessage.message.search("Rate exceeded") !== -1
     ) {
       //We were rate-limited, so add 15 seconds to the wait time
-      let newWait = wait + 15000;
+      let newWait = wait + backOff;
 
       //Sleep before trying again
       await new Promise(resolve => setTimeout(resolve, newWait));

--- a/code-build.js
+++ b/code-build.js
@@ -47,8 +47,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
   const { cloudWatchLogsArn } = logs;
   const { logGroupName, logStreamName } = logName(cloudWatchLogsArn);
 
-  let errorDetected = false;
-  let errObject = {};
+  let errObject = false;
 
   // Check the state
   const [batch, cloudWatch = {}] = await Promise.all([
@@ -59,13 +58,12 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
         .getLogEvents({ logGroupName, logStreamName, startFromHead, nextToken })
         .promise()
   ]).catch(err => {
-    errorDetected = true;
     errObject = err;
 
     return [];
   });
 
-  if (errorDetected) {
+  if (errObject) {
     //We caught an error in trying to make the AWS api call, and are now checking to see if it was just a rate limiting error
     if (errObject.message && errObject.message.search("Rate exceeded") !== -1) {
       //We were rate-limited, so add `backOff` seconds to the wait time

--- a/code-build.js
+++ b/code-build.js
@@ -71,7 +71,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
       errMessage.message &&
       errMessage.message.search("Rate exceeded") !== -1
     ) {
-      //We were rate-limited, so add 15 seconds to the wait time
+      //We were rate-limited, so add `backUp` seconds to the wait time
       let newWait = wait + backOff;
 
       //Sleep before trying again

--- a/code-build.js
+++ b/code-build.js
@@ -74,26 +74,27 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
       //The error returned from the API wasn't about rate limiting, so throw it as an actual error and fail the job
       throw errMessage;
     }
-  } else {
-    // Pluck off the relevant state
-    const [current] = batch.builds;
-    const { nextForwardToken, events = [] } = cloudWatch;
-
-    // stdout the CloudWatchLog (everyone likes progress...)
-    // CloudWatchLogs have line endings.
-    // I trim and then log each line
-    // to ensure that the line ending is OS specific.
-    events.forEach(({ message }) => console.log(message.trimEnd()));
-
-    // We did it! We can stop looking!
-    if (current.endTime && !events.length) return current;
-
-    // More to do: Sleep for a few seconds to avoid rate limiting
-    await new Promise(resolve => setTimeout(resolve, wait));
-
-    // Try again
-    return waitForBuildEndTime(sdk, current, nextForwardToken);
   }
+
+  // Pluck off the relevant state
+  const [current] = batch.builds;
+  const { nextForwardToken, events = [] } = cloudWatch;
+
+  // stdout the CloudWatchLog (everyone likes progress...)
+  // CloudWatchLogs have line endings.
+  // I trim and then log each line
+  // to ensure that the line ending is OS specific.
+  events.forEach(({ message }) => console.log(message.trimEnd()));
+
+  // We did it! We can stop looking!
+  if (current.endTime && !events.length) return current;
+
+  // More to do: Sleep for a few seconds to avoid rate limiting
+  await new Promise(resolve => setTimeout(resolve, wait));
+
+  // Try again
+  return waitForBuildEndTime(sdk, current, nextForwardToken);
+
 }
 
 function githubInputs() {

--- a/code-build.js
+++ b/code-build.js
@@ -59,7 +59,11 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
         .promise()
   ]).catch(err => {
     errObject = err;
-
+/* Returning [] here so that the assignment above
+ * does not throw `TypeError: undefined is not iterable`.
+ * The error is handled below,
+ * since it might be a rate limit.
+ */
     return [];
   });
 

--- a/code-build.js
+++ b/code-build.js
@@ -55,12 +55,12 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
         .promise()
   ]).catch((err) => {
     errorDetected = true;
-    errMessage = err.message;
+    errMessage = err;
   });
 
   if(errorDetected) {
     //We caught an error in trying to make the AWS api call, and are now checking to see if it was just a rate limiting error
-    if(errMessage.search('Rate exceeded') !== -1) {
+    if(errMessage.message && errMessage.message.search('Rate exceeded') !== -1) {
 
       //We were rate-limited, so add 15 seconds to the wait time
       let newWait = wait + 15000;

--- a/code-build.js
+++ b/code-build.js
@@ -64,7 +64,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
   // We did it! We can stop looking!
   if (current.endTime && !events.length) return current;
 
-  // More to do: Sleep for 5 seconds :)
+  // More to do: Sleep for 30 seconds :)
   await new Promise(resolve => setTimeout(resolve, wait));
 
   // Try again

--- a/code-build.js
+++ b/code-build.js
@@ -43,7 +43,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
   const { logGroupName, logStreamName } = logName(cloudWatchLogsArn);
 
   let errorDetected = false;
-  let errMessage = '';
+  let errMessage = "";
 
   // Check the state
   const [batch, cloudWatch = {}] = await Promise.all([
@@ -53,15 +53,19 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
       cloudWatchLogs
         .getLogEvents({ logGroupName, logStreamName, startFromHead, nextToken })
         .promise()
-  ]).catch((err) => {
+  ]).catch(err => {
     errorDetected = true;
     errMessage = err;
+
+    return [];
   });
 
-  if(errorDetected) {
+  if (errorDetected) {
     //We caught an error in trying to make the AWS api call, and are now checking to see if it was just a rate limiting error
-    if(errMessage.message && errMessage.message.search('Rate exceeded') !== -1) {
-
+    if (
+      errMessage.message &&
+      errMessage.message.search("Rate exceeded") !== -1
+    ) {
       //We were rate-limited, so add 15 seconds to the wait time
       let newWait = wait + 15000;
 
@@ -69,7 +73,11 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
       await new Promise(resolve => setTimeout(resolve, newWait));
 
       // Try again from the same token position
-      return waitForBuildEndTime({ ...sdk, wait: newWait }, { id, logs }, nextToken);
+      return waitForBuildEndTime(
+        { ...sdk, wait: newWait },
+        { id, logs },
+        nextToken
+      );
     } else {
       //The error returned from the API wasn't about rate limiting, so throw it as an actual error and fail the job
       throw errMessage;
@@ -94,7 +102,6 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
 
   // Try again
   return waitForBuildEndTime(sdk, current, nextForwardToken);
-
 }
 
 function githubInputs() {

--- a/code-build.js
+++ b/code-build.js
@@ -35,7 +35,7 @@ async function build(sdk, params) {
 }
 
 async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
-  const { codeBuild, cloudWatchLogs, wait = 1000 * 5 } = sdk;
+  const { codeBuild, cloudWatchLogs, wait = 1000 * 30 } = sdk;
 
   // Get the CloudWatchLog info
   const startFromHead = true;

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -320,7 +320,6 @@ describe("waitForBuildEndTime", () => {
   });
 
   it("waits after being rate limited and tries again", async function() {
-    //this.timeout(45000);
     const buildID = "buildID";
     const nullArn =
       "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
@@ -368,7 +367,6 @@ describe("waitForBuildEndTime", () => {
   });
 
   it("dies after getting an error from the aws sdk that isn't rate limiting", async function() {
-    //this.timeout(45000);
     const buildID = "buildID";
     const nullArn =
       "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -318,6 +318,104 @@ describe("waitForBuildEndTime", () => {
     });
     expect(test).to.equal(buildReplies.pop().builds[0]);
   });
+
+  it("waits after being rate limited and tries again", async function() {
+    this.timeout(45000);
+    const buildID = "buildID";
+    const nullArn =
+      "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
+    const cloudWatchLogsArn =
+      "arn:aws:logs:us-west-2:111122223333:log-group:/aws/codebuild/CloudWatchLogGroup:log-stream:1234abcd-12ab-34cd-56ef-1234567890ab";
+
+    const buildReplies = [
+      () => {
+        throw { message: "Rate exceeded" };
+      },
+      { builds: [{ id: buildID, logs: { cloudWatchLogsArn } }] },
+      {
+        builds: [
+          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" }
+        ]
+      }
+    ];
+
+    const sdk = help(
+      () => {
+        //similar to the ret function in the helper, allows me to throw an error in a function or return a more standard reply
+        let reply = buildReplies.shift();
+
+        if (typeof reply === "function") return reply();
+        return reply;
+      },
+      () => {
+        if (!buildReplies.length) {
+          return { events: [] };
+        }
+
+        return { events: [{ message: "got one" }] };
+      }
+    );
+
+    const test = await waitForBuildEndTime(sdk, {
+      id: buildID,
+      logs: { cloudWatchLogsArn: nullArn }
+    });
+
+    expect(test.id).to.equal(buildID);
+  });
+
+  it("dies after getting an error from the aws sdk that isn't rate limiting", async function() {
+    this.timeout(45000);
+    const buildID = "buildID";
+    const nullArn =
+      "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
+    const cloudWatchLogsArn =
+      "arn:aws:logs:us-west-2:111122223333:log-group:/aws/codebuild/CloudWatchLogGroup:log-stream:1234abcd-12ab-34cd-56ef-1234567890ab";
+
+    const buildReplies = [
+      () => {
+        throw { message: "Some AWS error" };
+      },
+      { builds: [{ id: buildID, logs: { cloudWatchLogsArn } }] },
+      {
+        builds: [
+          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" }
+        ]
+      }
+    ];
+
+    const sdk = help(
+      () => {
+        //similar to the ret function in the helper, allows me to throw an error in a function or return a more standard reply
+        let reply = buildReplies.shift();
+
+        if (typeof reply === "function") return reply();
+        return reply;
+      },
+      () => {
+        if (!buildReplies.length) {
+          return { events: [] };
+        }
+
+        return { events: [{ message: "got one" }] };
+      }
+    );
+
+    //run the thing and it should fail
+    let didFail = false;
+
+    try {
+      await waitForBuildEndTime(sdk, {
+        id: buildID,
+        logs: { cloudWatchLogsArn: nullArn }
+      });
+    } catch (err) {
+      didFail = true;
+      expect(err.message).to.equal("Some AWS error");
+    }
+
+    expect(didFail).to.equal(true);
+  });
 });
 
 function help(builds, logs) {

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -320,7 +320,7 @@ describe("waitForBuildEndTime", () => {
   });
 
   it("waits after being rate limited and tries again", async function() {
-    this.timeout(45000);
+    //this.timeout(45000);
     const buildID = "buildID";
     const nullArn =
       "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
@@ -356,16 +356,19 @@ describe("waitForBuildEndTime", () => {
       }
     );
 
-    const test = await waitForBuildEndTime(sdk, {
-      id: buildID,
-      logs: { cloudWatchLogsArn: nullArn }
-    });
+    const test = await waitForBuildEndTime(
+      { ...sdk, wait: 1, backOff: 1 },
+      {
+        id: buildID,
+        logs: { cloudWatchLogsArn: nullArn }
+      }
+    );
 
     expect(test.id).to.equal(buildID);
   });
 
   it("dies after getting an error from the aws sdk that isn't rate limiting", async function() {
-    this.timeout(45000);
+    //this.timeout(45000);
     const buildID = "buildID";
     const nullArn =
       "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
@@ -386,7 +389,8 @@ describe("waitForBuildEndTime", () => {
 
     const sdk = help(
       () => {
-        //similar to the ret function in the helper, allows me to throw an error in a function or return a more standard reply
+        //similar to the ret function in the helper
+        //allows me to throw an error in a function or return a more standard reply
         let reply = buildReplies.shift();
 
         if (typeof reply === "function") return reply();
@@ -405,10 +409,13 @@ describe("waitForBuildEndTime", () => {
     let didFail = false;
 
     try {
-      await waitForBuildEndTime(sdk, {
-        id: buildID,
-        logs: { cloudWatchLogsArn: nullArn }
-      });
+      await waitForBuildEndTime(
+        { ...sdk, wait: 1, backOff: 1 },
+        {
+          id: buildID,
+          logs: { cloudWatchLogsArn: nullArn }
+        }
+      );
     } catch (err) {
       didFail = true;
       expect(err.message).to.equal("Some AWS error");


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-actions/aws-codebuild-run-build/issues/28

*Description of changes:*

 - Increased the sleep timeout value from 5 seconds to 30 seconds to avoid API throttling when checking the status of the CodeBuild job.  In the issue, 60 seconds was thrown out as a value but I don't think it needs to be as long as that.  30 seconds should strike a good balance between not making too many API requests vs. not delaying the build too long.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.