### PR TITLE
fix: Run `npm format`

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -13,7 +13,7 @@ module.exports = {
   inputs2Parameters,
   githubInputs,
   buildSdk,
-  logName
+  logName,
 };
 
 function runBuild() {
@@ -39,7 +39,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
     codeBuild,
     cloudWatchLogs,
     wait = 1000 * 30,
-    backOff = 1000 * 15
+    backOff = 1000 * 15,
   } = sdk;
 
   // Get the CloudWatchLog info
@@ -56,8 +56,8 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
     logGroupName &&
       cloudWatchLogs
         .getLogEvents({ logGroupName, logStreamName, startFromHead, nextToken })
-        .promise()
-  ]).catch(err => {
+        .promise(),
+  ]).catch((err) => {
     errObject = err;
     /* Returning [] here so that the assignment above
      * does not throw `TypeError: undefined is not iterable`.
@@ -74,7 +74,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
       let newWait = wait + backOff;
 
       //Sleep before trying again
-      await new Promise(resolve => setTimeout(resolve, newWait));
+      await new Promise((resolve) => setTimeout(resolve, newWait));
 
       // Try again from the same token position
       return waitForBuildEndTime(
@@ -102,7 +102,7 @@ async function waitForBuildEndTime(sdk, { id, logs }, nextToken) {
   if (current.endTime && !events.length) return current;
 
   // More to do: Sleep for a few seconds to avoid rate limiting
-  await new Promise(resolve => setTimeout(resolve, wait));
+  await new Promise((resolve) => setTimeout(resolve, wait));
 
   // Try again
   return waitForBuildEndTime(sdk, current, nextForwardToken);
@@ -121,8 +121,8 @@ function githubInputs() {
   const envPassthrough = core
     .getInput("env-vars-for-codebuild", { required: false })
     .split(",")
-    .map(i => i.trim())
-    .filter(i => i !== "");
+    .map((i) => i.trim())
+    .filter((i) => i !== "");
 
   return {
     projectName,
@@ -130,7 +130,7 @@ function githubInputs() {
     repo,
     sourceVersion,
     buildspecOverride,
-    envPassthrough
+    envPassthrough,
   };
 }
 
@@ -141,7 +141,7 @@ function inputs2Parameters(inputs) {
     repo,
     sourceVersion,
     buildspecOverride,
-    envPassthrough = []
+    envPassthrough = [],
   } = inputs;
 
   const sourceTypeOverride = "GITHUB";
@@ -161,17 +161,17 @@ function inputs2Parameters(inputs) {
     sourceTypeOverride,
     sourceLocationOverride,
     buildspecOverride,
-    environmentVariablesOverride
+    environmentVariablesOverride,
   };
 }
 
 function buildSdk() {
   const codeBuild = new aws.CodeBuild({
-    customUserAgent: "aws-actions/aws-codebuild-run-build"
+    customUserAgent: "aws-actions/aws-codebuild-run-build",
   });
 
   const cloudWatchLogs = new aws.CloudWatchLogs({
-    customUserAgent: "aws-actions/aws-codebuild-run-build"
+    customUserAgent: "aws-actions/aws-codebuild-run-build",
   });
 
   assert(
@@ -189,7 +189,7 @@ function logName(Arn) {
   if (logGroupName === "null" || logStreamName === "null")
     return {
       logGroupName: undefined,
-      logStreamName: undefined
+      logStreamName: undefined,
     };
   return { logGroupName, logStreamName };
 }

--- a/local.js
+++ b/local.js
@@ -13,23 +13,23 @@ const { projectName, buildspecOverride, envPassthrough, remote } = yargs
     alias: "p",
     describe: "AWS CodeBuild Project Name",
     demandOption: true,
-    type: "string"
+    type: "string",
   })
   .option("buildspec-override", {
     alias: "b",
     describe: "Path to buildspec file",
-    type: "string"
+    type: "string",
   })
   .option("env-vars-for-codebuild", {
     alias: "e",
     describe: "List of environment variables to send to CodeBuild",
-    type: "array"
+    type: "array",
   })
   .option("remote", {
     alias: "r",
     describe: "remote name to publish to",
     default: "origin",
-    type: "string"
+    type: "string",
   }).argv;
 
 const BRANCH_NAME = uuid();
@@ -39,7 +39,7 @@ const params = cb.inputs2Parameters({
   ...githubInfo(remote),
   sourceVersion: BRANCH_NAME,
   buildspecOverride,
-  envPassthrough
+  envPassthrough,
 });
 
 const sdk = cb.buildSdk();
@@ -48,7 +48,7 @@ pushBranch(remote, BRANCH_NAME);
 
 cb.build(sdk, params)
   .then(() => deleteBranch(remote, BRANCH_NAME))
-  .catch(err => {
+  .catch((err) => {
     deleteBranch(remote, BRANCH_NAME);
     throw err;
   });
@@ -79,7 +79,7 @@ function githubInfo(remote) {
     .execSync("git remote -v")
     .toString()
     .split("\n")
-    .filter(line => line.trim().match(remoteMatch));
+    .filter((line) => line.trim().match(remoteMatch));
   assert(gitRemote, `No remote found named ${remote}`);
   const [, url] = gitRemote.split(/[\t ]/);
   if (url.startsWith(gitHubHTTPS)) {

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -5,7 +5,7 @@ const {
   logName,
   githubInputs,
   inputs2Parameters,
-  waitForBuildEndTime
+  waitForBuildEndTime,
 } = require("../code-build");
 const { expect } = require("chai");
 
@@ -26,12 +26,8 @@ describe("logName", () => {
     const arn =
       "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
     const test = logName(arn);
-    expect(test)
-      .to.haveOwnProperty("logGroupName")
-      .and.to.equal(undefined);
-    expect(test)
-      .to.haveOwnProperty("logStreamName")
-      .and.to.equal(undefined);
+    expect(test).to.haveOwnProperty("logGroupName").and.to.equal(undefined);
+    expect(test).to.haveOwnProperty("logStreamName").and.to.equal(undefined);
   });
 });
 
@@ -52,24 +48,14 @@ describe("githubInputs", () => {
     process.env[`GITHUB_REPOSITORY`] = repoInfo;
     process.env[`GITHUB_SHA`] = sha;
     const test = githubInputs();
-    expect(test)
-      .to.haveOwnProperty("projectName")
-      .and.to.equal(projectName);
-    expect(test)
-      .to.haveOwnProperty("sourceVersion")
-      .and.to.equal(sha);
-    expect(test)
-      .to.haveOwnProperty("owner")
-      .and.to.equal(`owner`);
-    expect(test)
-      .to.haveOwnProperty("repo")
-      .and.to.equal(`repo`);
+    expect(test).to.haveOwnProperty("projectName").and.to.equal(projectName);
+    expect(test).to.haveOwnProperty("sourceVersion").and.to.equal(sha);
+    expect(test).to.haveOwnProperty("owner").and.to.equal(`owner`);
+    expect(test).to.haveOwnProperty("repo").and.to.equal(`repo`);
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
-    expect(test)
-      .to.haveOwnProperty("envPassthrough")
-      .and.to.deep.equal([]);
+    expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
   });
 
   it("a project name is required.", () => {
@@ -120,14 +106,10 @@ describe("inputs2Parameters", () => {
       projectName,
       sourceVersion: sha,
       owner: "owner",
-      repo: "repo"
+      repo: "repo",
     });
-    expect(test)
-      .to.haveOwnProperty("projectName")
-      .and.to.equal(projectName);
-    expect(test)
-      .to.haveOwnProperty("sourceVersion")
-      .and.to.equal(sha);
+    expect(test).to.haveOwnProperty("projectName").and.to.equal(projectName);
+    expect(test).to.haveOwnProperty("sourceVersion").and.to.equal(sha);
     expect(test)
       .to.haveOwnProperty("sourceTypeOverride")
       .and.to.equal("GITHUB");
@@ -149,25 +131,15 @@ describe("inputs2Parameters", () => {
     expect(repoEnv)
       .to.haveOwnProperty("name")
       .and.to.equal("GITHUB_REPOSITORY");
-    expect(repoEnv)
-      .to.haveOwnProperty("value")
-      .and.to.equal(repoInfo);
-    expect(repoEnv)
-      .to.haveOwnProperty("type")
-      .and.to.equal("PLAINTEXT");
+    expect(repoEnv).to.haveOwnProperty("value").and.to.equal(repoInfo);
+    expect(repoEnv).to.haveOwnProperty("type").and.to.equal("PLAINTEXT");
 
     const [shaEnv] = test.environmentVariablesOverride.filter(
       ({ name }) => name === "GITHUB_SHA"
     );
-    expect(shaEnv)
-      .to.haveOwnProperty("name")
-      .and.to.equal("GITHUB_SHA");
-    expect(shaEnv)
-      .to.haveOwnProperty("value")
-      .and.to.equal(sha);
-    expect(shaEnv)
-      .to.haveOwnProperty("type")
-      .and.to.equal("PLAINTEXT");
+    expect(shaEnv).to.haveOwnProperty("name").and.to.equal("GITHUB_SHA");
+    expect(shaEnv).to.haveOwnProperty("value").and.to.equal(sha);
+    expect(shaEnv).to.haveOwnProperty("type").and.to.equal("PLAINTEXT");
   });
 
   it("can process env-vars-for-codebuild", () => {
@@ -191,7 +163,7 @@ describe("inputs2Parameters", () => {
       sourceVersion: sha,
       owner: "owner",
       repo: "repo",
-      envPassthrough: ["one", "two", "three", "four"]
+      envPassthrough: ["one", "two", "three", "four"],
     });
 
     expect(test)
@@ -201,54 +173,30 @@ describe("inputs2Parameters", () => {
     const [oneEnv] = test.environmentVariablesOverride.filter(
       ({ name }) => name === "one"
     );
-    expect(oneEnv)
-      .to.haveOwnProperty("name")
-      .and.to.equal("one");
-    expect(oneEnv)
-      .to.haveOwnProperty("value")
-      .and.to.equal("_one_");
-    expect(oneEnv)
-      .to.haveOwnProperty("type")
-      .and.to.equal("PLAINTEXT");
+    expect(oneEnv).to.haveOwnProperty("name").and.to.equal("one");
+    expect(oneEnv).to.haveOwnProperty("value").and.to.equal("_one_");
+    expect(oneEnv).to.haveOwnProperty("type").and.to.equal("PLAINTEXT");
 
     const [twoEnv] = test.environmentVariablesOverride.filter(
       ({ name }) => name === "two"
     );
-    expect(twoEnv)
-      .to.haveOwnProperty("name")
-      .and.to.equal("two");
-    expect(twoEnv)
-      .to.haveOwnProperty("value")
-      .and.to.equal("_two_");
-    expect(twoEnv)
-      .to.haveOwnProperty("type")
-      .and.to.equal("PLAINTEXT");
+    expect(twoEnv).to.haveOwnProperty("name").and.to.equal("two");
+    expect(twoEnv).to.haveOwnProperty("value").and.to.equal("_two_");
+    expect(twoEnv).to.haveOwnProperty("type").and.to.equal("PLAINTEXT");
 
     const [threeEnv] = test.environmentVariablesOverride.filter(
       ({ name }) => name === "three"
     );
-    expect(threeEnv)
-      .to.haveOwnProperty("name")
-      .and.to.equal("three");
-    expect(threeEnv)
-      .to.haveOwnProperty("value")
-      .and.to.equal("_three_");
-    expect(threeEnv)
-      .to.haveOwnProperty("type")
-      .and.to.equal("PLAINTEXT");
+    expect(threeEnv).to.haveOwnProperty("name").and.to.equal("three");
+    expect(threeEnv).to.haveOwnProperty("value").and.to.equal("_three_");
+    expect(threeEnv).to.haveOwnProperty("type").and.to.equal("PLAINTEXT");
 
     const [fourEnv] = test.environmentVariablesOverride.filter(
       ({ name }) => name === "four"
     );
-    expect(fourEnv)
-      .to.haveOwnProperty("name")
-      .and.to.equal("four");
-    expect(fourEnv)
-      .to.haveOwnProperty("value")
-      .and.to.equal("_four_");
-    expect(fourEnv)
-      .to.haveOwnProperty("type")
-      .and.to.equal("PLAINTEXT");
+    expect(fourEnv).to.haveOwnProperty("name").and.to.equal("four");
+    expect(fourEnv).to.haveOwnProperty("value").and.to.equal("_four_");
+    expect(fourEnv).to.haveOwnProperty("type").and.to.equal("PLAINTEXT");
   });
 });
 
@@ -262,9 +210,9 @@ describe("waitForBuildEndTime", () => {
     const buildReplies = [
       {
         builds: [
-          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" }
-        ]
-      }
+          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" },
+        ],
+      },
     ];
     const logReplies = [{ events: [] }];
     const sdk = help(
@@ -274,13 +222,13 @@ describe("waitForBuildEndTime", () => {
 
     const test = await waitForBuildEndTime(sdk, {
       id: buildID,
-      logs: { cloudWatchLogsArn }
+      logs: { cloudWatchLogsArn },
     });
 
     expect(test).to.equal(buildReplies.pop().builds[0]);
   });
 
-  it("waits for a build endTime **and** no cloud watch log events", async function() {
+  it("waits for a build endTime **and** no cloud watch log events", async function () {
     this.timeout(25000);
     let count = 0;
     const buildID = "buildID";
@@ -293,19 +241,19 @@ describe("waitForBuildEndTime", () => {
       { builds: [{ id: buildID, logs: { cloudWatchLogsArn } }] },
       {
         builds: [
-          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" }
-        ]
+          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" },
+        ],
       },
       {
         builds: [
-          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" }
-        ]
-      }
+          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" },
+        ],
+      },
     ];
     const logReplies = [
       undefined,
       { events: [{ message: "got one" }] },
-      { events: [] }
+      { events: [] },
     ];
     const sdk = help(
       () => buildReplies[count++],
@@ -314,12 +262,12 @@ describe("waitForBuildEndTime", () => {
 
     const test = await waitForBuildEndTime(sdk, {
       id: buildID,
-      logs: { cloudWatchLogsArn: nullArn }
+      logs: { cloudWatchLogsArn: nullArn },
     });
     expect(test).to.equal(buildReplies.pop().builds[0]);
   });
 
-  it("waits after being rate limited and tries again", async function() {
+  it("waits after being rate limited and tries again", async function () {
     const buildID = "buildID";
     const nullArn =
       "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
@@ -333,9 +281,9 @@ describe("waitForBuildEndTime", () => {
       { builds: [{ id: buildID, logs: { cloudWatchLogsArn } }] },
       {
         builds: [
-          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" }
-        ]
-      }
+          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" },
+        ],
+      },
     ];
 
     const sdk = help(
@@ -359,14 +307,14 @@ describe("waitForBuildEndTime", () => {
       { ...sdk, wait: 1, backOff: 1 },
       {
         id: buildID,
-        logs: { cloudWatchLogsArn: nullArn }
+        logs: { cloudWatchLogsArn: nullArn },
       }
     );
 
     expect(test.id).to.equal(buildID);
   });
 
-  it("dies after getting an error from the aws sdk that isn't rate limiting", async function() {
+  it("dies after getting an error from the aws sdk that isn't rate limiting", async function () {
     const buildID = "buildID";
     const nullArn =
       "arn:aws:logs:us-west-2:111122223333:log-group:null:log-stream:null";
@@ -380,9 +328,9 @@ describe("waitForBuildEndTime", () => {
       { builds: [{ id: buildID, logs: { cloudWatchLogsArn } }] },
       {
         builds: [
-          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" }
-        ]
-      }
+          { id: buildID, logs: { cloudWatchLogsArn }, endTime: "endTime" },
+        ],
+      },
     ];
 
     const sdk = help(
@@ -411,7 +359,7 @@ describe("waitForBuildEndTime", () => {
         { ...sdk, wait: 1, backOff: 1 },
         {
           id: buildID,
-          logs: { cloudWatchLogsArn: nullArn }
+          logs: { cloudWatchLogsArn: nullArn },
         }
       );
     } catch (err) {
@@ -429,9 +377,9 @@ function help(builds, logs) {
       return {
         async promise() {
           return ret(builds);
-        }
+        },
       };
-    }
+    },
   };
 
   const cloudWatchLogs = {
@@ -439,9 +387,9 @@ function help(builds, logs) {
       return {
         async promise() {
           return ret(logs);
-        }
+        },
       };
-    }
+    },
   };
 
   return { codeBuild, cloudWatchLogs, wait: 10 };


### PR DESCRIPTION
The linting rules were not run on a specific change.
This formats things to clean up the codebase

This should simplify #40 by moving all the lint changes here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

