### PR TITLE
Change version to v1 instead of v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ the only CodeBuild Run input you need to provide is the project name.
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     aws-region: us-east-2
 - name: Run CodeBuild
-  uses: aws-actions/aws-codebuild-run-project@v1.0.0
+  uses: aws-actions/aws-codebuild-run-project@v1
   with:
     project-name: CodeBuildProjectName
 ```
@@ -158,7 +158,7 @@ this will overwrite them.
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     aws-region: us-east-2
 - name: Run CodeBuild
-  uses: aws-actions/aws-codebuild-run-project@v1.0.0
+  uses: aws-actions/aws-codebuild-run-project@v1
   with:
     project-name: CodeBuildProjectName
     buildspec-override: path/to/buildspec.yaml


### PR DESCRIPTION
*Description of changes:* Change the version in the README example to v1 (instead of v1.0.0).

My coworkers and I were constantly getting the message "Waiting for DOWNLOAD_SOURCE" when creating pull requests, which then led to the error "Build status: FAILED".

We have been struggling with this problem for quite some time, and I recently realized that we were using an old version of this package because the example uses version 1.0.0, even though the most recent version is 1.0.3.

Most people who use this package will probably just copy the example, which means that they will be using an old version (v1.0.0) instead of the most recent version (v1.0.3 currently).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

