### PR TITLE
feat: Add batch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ In order to use this tool,
 you must first `git checkout` the commit that you want to test.
 
 ```
-npx @aws-actions/codebuild-run-build -p ProjectName -r remoteName
+npx https://github.com/aws-actions/aws-codebuild-run-build.git -p ProjectName -r remoteName
 ```
 
 This will use whatever commit you have checked out

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   buildspec-override:
     description: 'Buildspec Override'
     required: false
+  batch:
+    description: 'Run as an AWS CodeBuild batch'
+    required: false
   env-vars-for-codebuild:
     description: 'Comma separated list of environment variables to send to CodeBuild'
     required: false

--- a/local.js
+++ b/local.js
@@ -8,7 +8,7 @@ const cb = require("./code-build");
 const assert = require("assert");
 const yargs = require("yargs");
 
-const { projectName, buildspecOverride, envPassthrough, remote } = yargs
+const { projectName, buildspecOverride, envPassthrough, remote, batch } = yargs
   .option("project-name", {
     alias: "p",
     describe: "AWS CodeBuild Project Name",
@@ -30,6 +30,11 @@ const { projectName, buildspecOverride, envPassthrough, remote } = yargs
     describe: "remote name to publish to",
     default: "origin",
     type: "string",
+  })
+  .option("batch", {
+    describe: "Run as AWS CodeBuild batch build",
+    type: "boolean",
+    default: false,
   }).argv;
 
 const BRANCH_NAME = uuid();
@@ -46,7 +51,8 @@ const sdk = cb.buildSdk();
 
 pushBranch(remote, BRANCH_NAME);
 
-cb.build(sdk, params)
+// Need to select batch or build mode
+(batch ? cb.buildBatch(sdk, params) : cb.build(sdk, params))
   .then(() => deleteBranch(remote, BRANCH_NAME))
   .catch((err) => {
     deleteBranch(remote, BRANCH_NAME);

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,12 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = function () {
+  return {
+    files: ["./code-build.js"],
+    tests: ["test/code-build-test.js"],
+    testFramework: "mocha",
+    env: { type: "node" },
+    debug: true,
+  };
+};


### PR DESCRIPTION
CodeBuild supports batches.
A single buildspec can kick off several batches.

This adds support for both running as a command line as well as running as a GitHub action.

Additional
* Update the Readme with the correct `npx` command
* Add wallaby conf for faster testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

