### PR TITLE
docs: use v1 tracking tag in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ the only CodeBuild Run input you need to provide is the project name.
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     aws-region: us-east-2
 - name: Run CodeBuild
-  uses: aws-actions/aws-codebuild-run-build@v1.0.3
+  uses: aws-actions/aws-codebuild-run-build@v1
   with:
     project-name: CodeBuildProjectName
 ```
@@ -158,7 +158,7 @@ this will overwrite them.
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     aws-region: us-east-2
 - name: Run CodeBuild
-  uses: aws-actions/aws-codebuild-run-build@v1.0.3
+  uses: aws-actions/aws-codebuild-run-build@v1
   with:
     project-name: CodeBuildProjectName
     buildspec-override: path/to/buildspec.yaml


### PR DESCRIPTION
Avoid having to update the example with every new version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

