### PR TITLE
ease credential check.

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -225,10 +225,9 @@ function buildSdk() {
     customUserAgent: "aws-actions/aws-codebuild-run-build",
   });
 
-  assert(
-    codeBuild.config.credentials && cloudWatchLogs.config.credentials,
-    "No credentials. Try adding @aws-actions/configure-aws-credentials earlier in your job to set up AWS credentials."
-  );
+  if (codeBuild.config.credentials === null || cloudWatchLogs.config.credentials === null) {
+    console.log("If you might have credentials trouble, try adding @aws-actions/configure-aws-credentials earlier in your job to set up AWS credentials.")
+  }
 
   return { codeBuild, cloudWatchLogs };
 }


### PR DESCRIPTION
*Issue #74, if available:*

*Description of changes:*

This article
[AWS federation comes to GitHub Actions](https://awsteele.com/blog/2021/09/15/aws-federation-comes-to-github-actions.html)
explains we can use OIDC federated IAM Role in github actions workflow.

But now I got this error with aws-actions/aws-codebuild-run-build@v1.
```
Error: No credentials. Try adding @aws-actions/configure-aws-credentials earlier in your job to set up AWS credentials.
```

Simply comment out this assert, it works well.
https://github.com/aws-actions/aws-codebuild-run-build/blob/8945a85e94fd346070a0d8a28da303dbdd80b4bf/code-build.js#L228_L230
```
 assert(
    codeBuild.config.credentials && cloudWatchLogs.config.credentials,
    "No credentials. Try adding @aws-actions/configure-aws-credentials earlier in your job to set up AWS credentials."
  );
```

so for the moment I suggest just log this as warning insted of assert.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [x] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
