### PR TITLE
Issue #76: Add configurable update rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ The only required input is `project-name`.
    the one defined here replaces the one in the CodeBuild project.
    For a list of CodeBuild environment variables, see
 
+1. **update-interval** (optional) :
+   Update interval as seconds for how often the API is called to check on the status.
+
+   A higher value mitigates the chance of hitting API rate-limiting especially when
+   running many instances of this action in parallel, but also introduces a larger
+   potential time overhead (ranging from 0 to update interval) for the action to
+   fetch the build result and finish.
+
+   Lower value limits the potential time overhead worst case but it may hit the API
+   rate-limit more often, depending on the use-case.
+
+   The default value is 30.
+
+1. **update-back-off** (optional) :
+   Back-off time in seconds for the update interval.
+
+   When API rate-limiting is hit, the back-off time will be added to the next update
+   interval.
+   E.g. with update interval of 30 and back-off time of 15, upon hitting the rate-limit
+   the next interval for the update call will be 45s and if the rate-limit is hit again
+   the next interval will be 60s and so on.
+
+   The default value is 15.
+
 ### Outputs
 
 1. **aws-build-id** : The CodeBuild build ID of the build that the action ran.

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,12 @@ inputs:
   env-vars-for-codebuild:
     description: 'Comma separated list of environment variables to send to CodeBuild'
     required: false
+  update-interval:
+    description: 'How often the action calls the API for updates'
+    required: false
+  update-back-off:
+    description: 'Back-off time for the update calls for API if rate-limiting is encountered'
+    required: false
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'


### PR DESCRIPTION
*Issue #, if available:* #76

*Description of changes:*

- Add configurable update interval and back-off time. Slight refactoring was required in order to transfer the values from the GitHub inputs to where they are used. SDK-specific configuration parameters and general action configuration values (currently just the update rate configuration) are treated slightly differently and are passed as separate objects to the building and waiting functions.
- Add new test for handling the update rate configuration
- Update existing tests where needed
- Add new inputs to action metadata file
- Update README.md

Default values are kept the same (30s interval, 15s back-off), so there should be no breakage when updating.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

