### PR TITLE
Restrict permissions for the GITHUB_TOKEN in .github/workflows/ci-uni…

### DIFF
--- a/.github/workflows/ci-unit-tests.yaml
+++ b/.github/workflows/ci-unit-tests.yaml
@@ -4,6 +4,8 @@ on: [pull_request, push]
 
 jobs:
   ci-unit-tests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This commit was originally submitted by @varunsh-coder in https://github.com/aws-actions/aws-codebuild-run-build/pull/73

A new PR was necessary as the original repository is now deleted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

