### PR TITLE
Make getting the logs optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   env-vars-for-codebuild:
     description: 'Comma separated list of environment variables to send to CodeBuild'
     required: false
+  hide-log:
+    description: 'Hide the log output'
+    required: false
+    default: 'false'
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'


### PR DESCRIPTION
*Issue #, if available:*

The logs can be sensitive (i.e., by running proprietary software) and it should be possible to hide them.

*Description of changes:*

This change introduces an additional flag that allows hiding the log outputs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [x] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files. **No**

