### PR TITLE
feat: allow github action without source

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -152,7 +152,6 @@ async function waitForBuildEndTime(
 
 function githubInputs() {
   const projectName = core.getInput("project-name", { required: true });
-  const { owner, repo } = github.context.repo;
   const { payload } = github.context;
   // The github.context.sha is evaluated on import.
   // This makes it hard to test.
@@ -177,8 +176,6 @@ function githubInputs() {
 
   return {
     projectName,
-    owner,
-    repo,
     sourceVersion,
     buildspecOverride,
     envPassthrough,
@@ -195,9 +192,6 @@ function inputs2Parameters(inputs) {
     envPassthrough = [],
   } = inputs;
 
-  const sourceTypeOverride = "GITHUB";
-  const sourceLocationOverride = `https://github.com/${owner}/${repo}.git`;
-
   const environmentVariablesOverride = Object.entries(process.env)
     .filter(
       ([key]) => key.startsWith("GITHUB_") || envPassthrough.includes(key)
@@ -209,8 +203,6 @@ function inputs2Parameters(inputs) {
   return {
     projectName,
     sourceVersion,
-    sourceTypeOverride,
-    sourceLocationOverride,
     buildspecOverride,
     environmentVariablesOverride,
   };


### PR DESCRIPTION
As usual AWS half implemented this and it isn't compatiable with
private repos.  This removes the source as GitHub so you can check
out the code yourself.
https://github.com/aws-actions/aws-codebuild-run-build/issues/4

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

