### PR TITLE
Add image-override input to aws-codebuild-run-build action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The only required input is `project-name`.
    that CodeBuild requires.
    By default, the action uses the buildspec file location
    that you configured in the CodeBuild project.
+1. **image-override** (optional) :
+   The name of an image for this build that overrides the one specified
+   in the build project. By default, the action uses the default environment
+   that you configured in the CodeBuild project.
 1. **env-vars-for-codebuild** (optional) :
    A comma-separated list of the names of environment variables
    that the action passes from GitHub Actions to CodeBuild.
@@ -162,6 +166,7 @@ this will overwrite them.
   with:
     project-name: CodeBuildProjectName
     buildspec-override: path/to/buildspec.yaml
+    image-override: ecr-image-uri
     env-vars-for-codebuild: |
       custom,
       requester,

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   buildspec-override:
     description: 'Buildspec Override'
     required: false
+  image-override:
+    description: 'The name of an image for this build that overrides the one specified in the build project.'
+    required: false
   env-vars-for-codebuild:
     description: 'Comma separated list of environment variables to send to CodeBuild'
     required: false

--- a/code-build.js
+++ b/code-build.js
@@ -169,6 +169,9 @@ function githubInputs() {
   const buildspecOverride =
     core.getInput("buildspec-override", { required: false }) || undefined;
 
+  const imageOverride = 
+    core.getInput("image-override", { required: false }) || undefined;
+
   const envPassthrough = core
     .getInput("env-vars-for-codebuild", { required: false })
     .split(",")
@@ -181,6 +184,7 @@ function githubInputs() {
     repo,
     sourceVersion,
     buildspecOverride,
+    imageOverride,
     envPassthrough,
   };
 }
@@ -192,6 +196,7 @@ function inputs2Parameters(inputs) {
     repo,
     sourceVersion,
     buildspecOverride,
+    imageOverride,
     envPassthrough = [],
   } = inputs;
 
@@ -212,6 +217,7 @@ function inputs2Parameters(inputs) {
     sourceTypeOverride,
     sourceLocationOverride,
     buildspecOverride,
+    imageOverride,
     environmentVariablesOverride,
   };
 }

--- a/local.js
+++ b/local.js
@@ -8,7 +8,7 @@ const cb = require("./code-build");
 const assert = require("assert");
 const yargs = require("yargs");
 
-const { projectName, buildspecOverride, envPassthrough, remote } = yargs
+const { projectName, buildspecOverride, imageOverride, envPassthrough, remote } = yargs
   .option("project-name", {
     alias: "p",
     describe: "AWS CodeBuild Project Name",
@@ -18,6 +18,11 @@ const { projectName, buildspecOverride, envPassthrough, remote } = yargs
   .option("buildspec-override", {
     alias: "b",
     describe: "Path to buildspec file",
+    type: "string",
+  })
+  .option("image-override", {
+    alias: "i",
+    describe: "The name of an image for this build that overrides the one specified in the build project.",
     type: "string",
   })
   .option("env-vars-for-codebuild", {
@@ -39,6 +44,7 @@ const params = cb.inputs2Parameters({
   ...githubInfo(remote),
   sourceVersion: BRANCH_NAME,
   buildspecOverride,
+  imageOverride,
   envPassthrough,
 });
 

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -64,6 +64,7 @@ describe("githubInputs", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
+    expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
   });
 
@@ -113,6 +114,7 @@ describe("githubInputs", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
+    expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
   });
 
@@ -166,6 +168,7 @@ describe("inputs2Parameters", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
+    expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
 
     // I send everything that starts 'GITHUB_'
     expect(test)


### PR DESCRIPTION
This commit allows user to start build with image override by passing
image-override parameter to the action with desired ECR image URI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

