### PR TITLE
fix: gracefully handle logName on undefined Arn

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -234,13 +234,18 @@ function buildSdk() {
 }
 
 function logName(Arn) {
-  const [logGroupName, logStreamName] = Arn.split(":log-group:")
-    .pop()
-    .split(":log-stream:");
-  if (logGroupName === "null" || logStreamName === "null")
-    return {
-      logGroupName: undefined,
-      logStreamName: undefined,
-    };
-  return { logGroupName, logStreamName };
+  const logs = {
+    logGroupName: undefined,
+    logStreamName: undefined,
+  };
+  if (Arn) {
+    const [logGroupName, logStreamName] = Arn.split(":log-group:")
+      .pop()
+      .split(":log-stream:");
+    if (logGroupName !== "null" && logStreamName !== "null") {
+      logs.logGroupName = logGroupName;
+      logs.logStreamName = logStreamName;
+    }
+  }
+  return logs;
 }

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -29,6 +29,13 @@ describe("logName", () => {
     expect(test).to.haveOwnProperty("logGroupName").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("logStreamName").and.to.equal(undefined);
   });
+
+  it("return undefined when the Arn is undefined", () => {
+    const arn = undefined;
+    const test = logName(arn);
+    expect(test).to.haveOwnProperty("logGroupName").and.to.equal(undefined);
+    expect(test).to.haveOwnProperty("logStreamName").and.to.equal(undefined);
+  });
 });
 
 describe("githubInputs", () => {


### PR DESCRIPTION
*Issue #, if available: https://github.com/aws-actions/aws-codebuild-run-build/issues/98

*Description of changes:*
Apparently when triggering CodeBuild jobs we expected that the initial response to `startBuild` would include `logs.cloudWatchLogsArn`. Maybe AWS updated their APIs, but the matter of fact is that this is no longer the case and the Arn won't be available during the provisioning phase of the CodeBuild project instance. This means that everyone currently using this action is getting an `Cannot read property 'split' of undefined` when trying to grab the log group and log stream.

This PR adds a conditional check in case Arn is not available yet so it returns undefined log-group and log-stream. A test case was also added to validate the behavior. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

