### PR TITLE
feat: Add configurable update rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ The only required input is `project-name`.
    The default value is 30.
 
 1. **update-back-off** (optional) :
-   Back-off time in seconds for the update interval.
+   Base back-off time in seconds for the update interval.
 
-   When API rate-limiting is hit, the back-off time will be added to the next update
-   interval.
+   When API rate-limiting is hit the back-off time, augmented with jitter, will be
+   added to the next update interval.
    E.g. with update interval of 30 and back-off time of 15, upon hitting the rate-limit
-   the next interval for the update call will be 45s and if the rate-limit is hit again
-   the next interval will be 60s and so on.
+   the next interval for the update call will be 30 + random_between(0, 15 _ 2 \*\* 0))
+   seconds and if the rate-limit is hit again the next interval will be
+   30 + random_between(0, 15 _ 2 \*\* 1) and so on.
 
    The default value is 15.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ The only required input is `project-name`.
    the one defined here replaces the one in the CodeBuild project.
    For a list of CodeBuild environment variables, see
 
+1. **update-interval** (optional) :
+   Update interval as seconds for how often the API is called to check on the status.
+
+   A higher value mitigates the chance of hitting API rate-limiting especially when
+   running many instances of this action in parallel, but also introduces a larger
+   potential time overhead (ranging from 0 to update interval) for the action to
+   fetch the build result and finish.
+
+   Lower value limits the potential time overhead worst case but it may hit the API
+   rate-limit more often, depending on the use-case.
+
+   The default value is 30.
+
+1. **update-back-off** (optional) :
+   Back-off time in seconds for the update interval.
+
+   When API rate-limiting is hit, the back-off time will be added to the next update
+   interval.
+   E.g. with update interval of 30 and back-off time of 15, upon hitting the rate-limit
+   the next interval for the update call will be 45s and if the rate-limit is hit again
+   the next interval will be 60s and so on.
+
+   The default value is 15.
+
 ### Outputs
 
 1. **aws-build-id** : The CodeBuild build ID of the build that the action ran.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,13 @@ inputs:
   env-vars-for-codebuild:
     description: 'Comma separated list of environment variables to send to CodeBuild'
     required: false
+  update-interval:
+    description: 'How often the action calls the API for updates'
+    required: false
+  update-back-off:
+    description: 'Back-off time for the update calls for API if rate-limiting is encountered'
+    required: false
+
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: 'How often the action calls the API for updates'
     required: false
   update-back-off:
-    description: 'Back-off time for the update calls for API if rate-limiting is encountered'
+    description: 'Base back-off time for the update calls for API if rate-limiting is encountered'
     required: false
 
 outputs:

--- a/code-build.js
+++ b/code-build.js
@@ -198,9 +198,15 @@ function githubInputs() {
     .filter((i) => i !== "");
 
   const updateInterval =
-    core.getInput("update-interval", { required: false }) || 1000 * 30;
+    parseInt(
+      core.getInput("update-interval", { required: false }) || "30",
+      10
+    ) * 1000;
   const updateBackOff =
-    core.getInput("update-back-off", { required: false }) || 1000 * 15;
+    parseInt(
+      core.getInput("update-back-off", { required: false }) || "15",
+      10
+    ) * 1000;
 
   return {
     projectName,

--- a/code-build.js
+++ b/code-build.js
@@ -89,8 +89,11 @@ async function waitForBuildEndTime(
   if (errObject) {
     //We caught an error in trying to make the AWS api call, and are now checking to see if it was just a rate limiting error
     if (errObject.message && errObject.message.search("Rate exceeded") !== -1) {
-      //We were rate-limited, so add `backOff` seconds to the wait time
-      let newWait = updateInterval + updateBackOff;
+      // We were rate-limited, so add backoff with Full Jitter, ref: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+      let jitteredBackOff = Math.floor(
+        Math.random() * (updateBackOff * 2 ** throttleCount)
+      );
+      let newWait = updateInterval + jitteredBackOff;
       throttleCount++;
 
       //Sleep before trying again

--- a/code-build.js
+++ b/code-build.js
@@ -20,34 +20,37 @@ function runBuild() {
   // get a codeBuild instance from the SDK
   const sdk = buildSdk();
 
-  // Get input options for startBuild
-  const params = inputs2Parameters(githubInputs());
+  const inputs = githubInputs();
 
-  return build(sdk, params);
+  const config = (({ updateInterval, updateBackOff }) => ({
+    updateInterval,
+    updateBackOff,
+  }))(inputs);
+
+  // Get input options for startBuild
+  const params = inputs2Parameters(inputs);
+
+  return build(sdk, params, config);
 }
 
-async function build(sdk, params) {
+async function build(sdk, params, config) {
   // Start the build
   const start = await sdk.codeBuild.startBuild(params).promise();
 
   // Wait for the build to "complete"
-  return waitForBuildEndTime(sdk, start.build);
+  return waitForBuildEndTime(sdk, start.build, config);
 }
 
 async function waitForBuildEndTime(
   sdk,
   { id, logs },
+  { updateInterval, updateBackOff },
   seqEmptyLogs,
   totalEvents,
   throttleCount,
   nextToken
 ) {
-  const {
-    codeBuild,
-    cloudWatchLogs,
-    wait = 1000 * 30,
-    backOff = 1000 * 15,
-  } = sdk;
+  const { codeBuild, cloudWatchLogs } = sdk;
 
   totalEvents = totalEvents || 0;
   seqEmptyLogs = seqEmptyLogs || 0;
@@ -87,7 +90,7 @@ async function waitForBuildEndTime(
     //We caught an error in trying to make the AWS api call, and are now checking to see if it was just a rate limiting error
     if (errObject.message && errObject.message.search("Rate exceeded") !== -1) {
       //We were rate-limited, so add `backOff` seconds to the wait time
-      let newWait = wait + backOff;
+      let newWait = updateInterval + updateBackOff;
       throttleCount++;
 
       //Sleep before trying again
@@ -95,8 +98,9 @@ async function waitForBuildEndTime(
 
       // Try again from the same token position
       return waitForBuildEndTime(
-        { ...sdk, wait: newWait },
+        { ...sdk },
         { id, logs },
+        { updateInterval: newWait, updateBackOff },
         seqEmptyLogs,
         totalEvents,
         throttleCount,
@@ -136,13 +140,19 @@ async function waitForBuildEndTime(
   // More to do: Sleep for a few seconds to avoid rate limiting
   // If never throttled and build is complete, halve CWL polling delay to minimize latency
   await new Promise((resolve) =>
-    setTimeout(resolve, current.endTime && throttleCount == 0 ? wait / 2 : wait)
+    setTimeout(
+      resolve,
+      current.endTime && throttleCount == 0
+        ? updateInterval / 2
+        : updateInterval
+    )
   );
 
   // Try again
   return waitForBuildEndTime(
     sdk,
     current,
+    { updateInterval, updateBackOff },
     seqEmptyLogs,
     totalEvents,
     throttleCount,
@@ -173,8 +183,9 @@ function githubInputs() {
     core.getInput("compute-type-override", { required: false }) || undefined;
 
   const environmentTypeOverride =
-    core.getInput("environment-type-override", { required: false }) || undefined;
-  const imageOverride = 
+    core.getInput("environment-type-override", { required: false }) ||
+    undefined;
+  const imageOverride =
     core.getInput("image-override", { required: false }) || undefined;
 
   const envPassthrough = core
@@ -182,6 +193,11 @@ function githubInputs() {
     .split(",")
     .map((i) => i.trim())
     .filter((i) => i !== "");
+
+  const updateInterval =
+    core.getInput("update-interval", { required: false }) || 1000 * 30;
+  const updateBackOff =
+    core.getInput("update-back-off", { required: false }) || 1000 * 15;
 
   return {
     projectName,
@@ -193,6 +209,8 @@ function githubInputs() {
     environmentTypeOverride,
     imageOverride,
     envPassthrough,
+    updateInterval,
+    updateBackOff,
   };
 }
 

--- a/local.js
+++ b/local.js
@@ -8,7 +8,15 @@ const cb = require("./code-build");
 const assert = require("assert");
 const yargs = require("yargs");
 
-const { projectName, buildspecOverride, computeTypeOverride, environmentTypeOverride, imageOverride, envPassthrough, remote } = yargs
+const {
+  projectName,
+  buildspecOverride,
+  computeTypeOverride,
+  environmentTypeOverride,
+  imageOverride,
+  envPassthrough,
+  remote,
+} = yargs
   .option("project-name", {
     alias: "p",
     describe: "AWS CodeBuild Project Name",
@@ -22,17 +30,20 @@ const { projectName, buildspecOverride, computeTypeOverride, environmentTypeOver
   })
   .option("compute-type-override", {
     alias: "c",
-    describe: "The name of a compute type for this build that overrides the one specified in the build project.",
+    describe:
+      "The name of a compute type for this build that overrides the one specified in the build project.",
     type: "string",
   })
   .option("environment-type-override", {
     alias: "et",
-    describe: "A container type for this build that overrides the one specified in the build project.",
+    describe:
+      "A container type for this build that overrides the one specified in the build project.",
     type: "string",
   })
   .option("image-override", {
     alias: "i",
-    describe: "The name of an image for this build that overrides the one specified in the build project.",
+    describe:
+      "The name of an image for this build that overrides the one specified in the build project.",
     type: "string",
   })
   .option("env-vars-for-codebuild", {

--- a/local.js
+++ b/local.js
@@ -16,6 +16,8 @@ const {
   imageOverride,
   envPassthrough,
   remote,
+  updateInterval,
+  updateBackOff,
 } = yargs
   .option("project-name", {
     alias: "p",
@@ -56,6 +58,17 @@ const {
     describe: "remote name to publish to",
     default: "origin",
     type: "string",
+  })
+  .option("update-interval", {
+    describe: "Interval in seconds between API calls for fetching updates",
+    default: 30,
+    type: "number",
+  })
+  .option("update-backoff", {
+    describe:
+      "Base update interval back-off value when encountering API rate-limiting",
+    default: 15,
+    type: "number",
   }).argv;
 
 const BRANCH_NAME = uuid();
@@ -71,11 +84,16 @@ const params = cb.inputs2Parameters({
   envPassthrough,
 });
 
+const config = {
+  updateInterval: updateInterval * 1000,
+  updateBackOff: updateBackOff * 1000,
+};
+
 const sdk = cb.buildSdk();
 
 pushBranch(remote, BRANCH_NAME);
 
-cb.build(sdk, params)
+cb.build(sdk, params, config)
   .then(() => deleteBranch(remote, BRANCH_NAME))
   .catch((err) => {
     deleteBranch(remote, BRANCH_NAME);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@actions/core": "^1.10.0",
+        "@actions/core": "^1.9.1",
         "@actions/exec": "^1.0.3",
         "@actions/github": "^2.1.1",
         "aws-sdk": "^2.814.0",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@actions/core": "^1.9.1",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.3",
         "@actions/github": "^2.1.1",
         "aws-sdk": "^2.814.0",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -54,8 +54,8 @@ describe("githubInputs", () => {
   const sha = "1234abcd-12ab-34cd-56ef-1234567890ab";
   const pullRequestSha = "181600acb3cfb803f4570d0018928be5d730c00d";
 
-  const updateInterval = "5";
-  const updateBackOff = "10";
+  const updateInterval = 5;
+  const updateBackOff = 10;
 
   it("build basic parameters for codeBuild.startBuild", () => {
     // This is how GITHUB injects its input values.
@@ -157,8 +157,8 @@ describe("githubInputs", () => {
   });
   it("can handle configuring update call-rate", () => {
     process.env[`INPUT_PROJECT-NAME`] = projectName;
-    process.env[`INPUT_UPDATE-INTERVAL`] = updateInterval;
-    process.env[`INPUT_UPDATE-BACK-OFF`] = updateBackOff;
+    process.env[`INPUT_UPDATE-INTERVAL`] = `${updateInterval}`;
+    process.env[`INPUT_UPDATE-BACK-OFF`] = `${updateBackOff}`;
     process.env[`GITHUB_REPOSITORY`] = repoInfo;
     process.env[`GITHUB_SHA`] = sha;
     const { context } = require("@actions/github");
@@ -168,10 +168,10 @@ describe("githubInputs", () => {
 
     expect(test)
       .to.haveOwnProperty("updateInterval")
-      .and.to.equal(updateInterval);
+      .and.to.equal(updateInterval * 1000);
     expect(test)
       .to.haveOwnProperty("updateBackOff")
-      .and.to.equal(updateBackOff);
+      .and.to.equal(updateBackOff * 1000);
   });
 });
 
@@ -358,7 +358,7 @@ describe("inputs2Parameters", () => {
 });
 
 describe("waitForBuildEndTime", () => {
-  const defaultConfig = { updateInterval: 30, updateBackOff: 15 };
+  const defaultConfig = { updateInterval: 10, updateBackOff: 10 }; // NOTE: milliseconds
   it("basic usages", async () => {
     let count = 0;
     const buildID = "buildID";

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -54,6 +54,9 @@ describe("githubInputs", () => {
   const sha = "1234abcd-12ab-34cd-56ef-1234567890ab";
   const pullRequestSha = "181600acb3cfb803f4570d0018928be5d730c00d";
 
+  const updateInterval = "5";
+  const updateBackOff = "10";
+
   it("build basic parameters for codeBuild.startBuild", () => {
     // This is how GITHUB injects its input values.
     // It would be nice if there was an easy way to test this...
@@ -71,8 +74,12 @@ describe("githubInputs", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("computeTypeOverride").and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("environmentTypeOverride").and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("computeTypeOverride")
+      .and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("environmentTypeOverride")
+      .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
   });
@@ -123,8 +130,12 @@ describe("githubInputs", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("computeTypeOverride").and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("environmentTypeOverride").and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("computeTypeOverride")
+      .and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("environmentTypeOverride")
+      .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
   });
@@ -143,6 +154,24 @@ describe("githubInputs", () => {
     expect(() => githubInputs()).to.throw(
       "No source version could be evaluated."
     );
+  });
+  it("can handle configuring update call-rate", () => {
+    process.env[`INPUT_PROJECT-NAME`] = projectName;
+    process.env[`INPUT_UPDATE-INTERVAL`] = updateInterval;
+    process.env[`INPUT_UPDATE-BACK-OFF`] = updateBackOff;
+    process.env[`GITHUB_REPOSITORY`] = repoInfo;
+    process.env[`GITHUB_SHA`] = sha;
+
+    require("@actions/github").context.payload = {};
+
+    const test = githubInputs();
+
+    expect(test)
+      .to.haveOwnProperty("updateInterval")
+      .and.to.equal(updateInterval);
+    expect(test)
+      .to.haveOwnProperty("updateBackOff")
+      .and.to.equal(updateBackOff);
   });
 });
 
@@ -179,8 +208,12 @@ describe("inputs2Parameters", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("computeTypeOverride").and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("environmentTypeOverride").and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("computeTypeOverride")
+      .and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("environmentTypeOverride")
+      .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
 
     // I send everything that starts 'GITHUB_'
@@ -218,7 +251,8 @@ describe("inputs2Parameters", () => {
       repo: "repo",
       computeTypeOverride: "BUILD_GENERAL1_LARGE",
       environmentTypeOverride: "LINUX_CONTAINER",
-      imageOverride: "111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo"
+      imageOverride:
+        "111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo",
     });
     expect(test).to.haveOwnProperty("projectName").and.to.equal(projectName);
     expect(test).to.haveOwnProperty("sourceVersion").and.to.equal(sha);
@@ -239,7 +273,9 @@ describe("inputs2Parameters", () => {
       .and.to.equal(`LINUX_CONTAINER`);
     expect(test)
       .to.haveOwnProperty("imageOverride")
-      .and.to.equal(`111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo`);
+      .and.to.equal(
+        `111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo`
+      );
 
     // I send everything that starts 'GITHUB_'
     expect(test)
@@ -322,6 +358,7 @@ describe("inputs2Parameters", () => {
 });
 
 describe("waitForBuildEndTime", () => {
+  const defaultConfig = { updateInterval: 30, updateBackOff: 15 };
   it("basic usages", async () => {
     let count = 0;
     const buildID = "buildID";
@@ -341,10 +378,14 @@ describe("waitForBuildEndTime", () => {
       () => logReplies[0]
     );
 
-    const test = await waitForBuildEndTime(sdk, {
-      id: buildID,
-      logs: { cloudWatchLogsArn },
-    });
+    const test = await waitForBuildEndTime(
+      sdk,
+      {
+        id: buildID,
+        logs: { cloudWatchLogsArn },
+      },
+      defaultConfig
+    );
 
     expect(test).to.equal(buildReplies.pop().builds[0]);
     expect(count).to.equal(2);
@@ -388,10 +429,15 @@ describe("waitForBuildEndTime", () => {
       () => logReplies[count - 1]
     );
 
-    const test = await waitForBuildEndTime(sdk, {
-      id: buildID,
-      logs: { cloudWatchLogsArn: nullArn },
-    });
+    const test = await waitForBuildEndTime(
+      sdk,
+      {
+        id: buildID,
+        logs: { cloudWatchLogsArn: nullArn },
+      },
+      defaultConfig
+    );
+
     expect(test).to.equal(buildReplies.pop().builds[0]);
     expect(count).to.equal(4);
   });
@@ -438,11 +484,12 @@ describe("waitForBuildEndTime", () => {
     );
 
     const test = await waitForBuildEndTime(
-      { ...sdk, wait: 1, backOff: 1 },
+      { ...sdk },
       {
         id: buildID,
         logs: { cloudWatchLogsArn: nullArn },
-      }
+      },
+      { updateInterval: 1, updateBackOff: 1 }
     );
 
     expect(test.id).to.equal(buildID);
@@ -490,11 +537,12 @@ describe("waitForBuildEndTime", () => {
 
     try {
       await waitForBuildEndTime(
-        { ...sdk, wait: 1, backOff: 1 },
+        { ...sdk },
         {
           id: buildID,
           logs: { cloudWatchLogsArn: nullArn },
-        }
+        },
+        defaultConfig
       );
     } catch (err) {
       didFail = true;
@@ -526,7 +574,7 @@ function help(builds, logs) {
     },
   };
 
-  return { codeBuild, cloudWatchLogs, wait: 10 };
+  return { codeBuild, cloudWatchLogs };
 
   function ret(thing) {
     if (typeof thing === "function") return thing();

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -161,8 +161,8 @@ describe("githubInputs", () => {
     process.env[`INPUT_UPDATE-BACK-OFF`] = updateBackOff;
     process.env[`GITHUB_REPOSITORY`] = repoInfo;
     process.env[`GITHUB_SHA`] = sha;
-
-    require("@actions/github").context.payload = {};
+    const { context } = require("@actions/github");
+    context.payload = { pull_request: { head: { sha: pullRequestSha } } };
 
     const test = githubInputs();
 


### PR DESCRIPTION
_Issue #, if available:_ #76
 
_Description of changes:_
 
* Add configurable update interval and back-off time. Slight refactoring was required in order to transfer the values from the GitHub inputs to where they are used. SDK-specific configuration parameters and general action configuration values (currently just the update rate configuration) are treated slightly differently and are passed as separate objects to the building and waiting functions.
* Add new test for handling the update rate configuration
* Update existing tests where needed
* Add new inputs to action metadata file
* Update README.md
 
Default values are kept the same (30s interval, 15s back-off), so there should be no breakage when updating.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 
# Check any applicable:
* [ ]  Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

Supercedes #77 (which can be closed).