### PR TITLE
Add packaging workflow, so that dist folder doesn't get out of date

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Package
+
+jobs:
+  check:
+    name: Package distribution file
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: main
+    - name: Package
+      run: |
+        npm ci
+        npm run lint
+        npm test
+        npm run package
+    - name: Commit
+      run: |
+        git config --global user.name "GitHub Actions"
+        git add dist/
+        git commit -m "chore: Update dist" || echo "No changes to commit"
+        git push origin HEAD:main


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-actions/aws-codebuild-run-build/pull/119

*Description of changes:* automatically update dist/index.js following the [amazon-ecr-login](https://github.com/aws-actions/amazon-ecr-login/blob/main/.github/workflows/package.yml) approach.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [n] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

