### PR TITLE
Fix an issue in inputs2Parameters(): `Error: Unexpected key 'disableSourceOverride' found in params`

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -264,7 +264,6 @@ function inputs2Parameters(inputs) {
     environmentTypeOverride,
     imageOverride,
     environmentVariablesOverride,
-    disableSourceOverride,
   };
 }
 

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -230,7 +230,6 @@ describe("inputs2Parameters", () => {
       .to.haveOwnProperty("environmentTypeOverride")
       .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("disableSourceOverride").and.to.equal(undefined);
 
     // I send everything that starts 'GITHUB_'
     expect(test)


### PR DESCRIPTION
*Issue #, if available:* seeing this error on the latest release https://github.com/taoyong-ty/aws-codebuild-run-build/actions/runs/4137008240/jobs/7151629480

This is because `disableSourceOverride` should not have been passed as an input to CodeBuild as input.

*Description of changes:* 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

