### PR TITLE
Update the hide-cloudwatch-logs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,14 @@ The only required input is `project-name`.
    When API rate-limiting is hit the back-off time, augmented with jitter, will be
    added to the next update interval.
    E.g. with update interval of 30 and back-off time of 15, upon hitting the rate-limit
-   the next interval for the update call will be 30 + random_between(0, 15 _ 2 \*\* 0))
+   the next interval for the update call will be 30 + random*between(0, 15 * 2 \*\* 0))
    seconds and if the rate-limit is hit again the next interval will be
-   30 + random_between(0, 15 _ 2 \*\* 1) and so on.
+   30 + random*between(0, 15 * 2 \*\* 1) and so on.
 
    The default value is 15.
+
+1. **hide-cloudwatch-logs** (optional) :
+   Set to `true` if you do not want CloudWatch logs to be streamed to GitHub Action.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
   disable-source-override:
     description: 'Set to `true` if you want do disable source repo override'
     required: false
+  hide-cloudwatch-logs:
+    description: 'Set to `true` to prevent the CloudWatch logs from streaming the output to GitHub'
+    required: false
+    default: false
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'

--- a/code-build.js
+++ b/code-build.js
@@ -22,9 +22,10 @@ function runBuild() {
 
   const inputs = githubInputs();
 
-  const config = (({ updateInterval, updateBackOff }) => ({
+  const config = (({ updateInterval, updateBackOff, hideCloudwatchLogs }) => ({
     updateInterval,
     updateBackOff,
+    hideCloudwatchLogs,
   }))(inputs);
 
   // Get input options for startBuild
@@ -44,7 +45,7 @@ async function build(sdk, params, config) {
 async function waitForBuildEndTime(
   sdk,
   { id, logs },
-  { updateInterval, updateBackOff },
+  { updateInterval, updateBackOff, hideCloudwatchLogs },
   seqEmptyLogs,
   totalEvents,
   throttleCount,
@@ -62,13 +63,12 @@ async function waitForBuildEndTime(
   const { logGroupName, logStreamName } = logName(cloudWatchLogsArn);
 
   let errObject = false;
-
   // Check the state
   const [batch, cloudWatch = {}] = await Promise.all([
     codeBuild.batchGetBuilds({ ids: [id] }).promise(),
-    // The CloudWatchLog _may_ not be set up, only make the call if we have a logGroupName
-    logGroupName &&
-      cloudWatchLogs
+    !hideCloudwatchLogs &&
+      logGroupName &&
+      cloudWatchLogs // only make the call if hideCloudwatchLogs is not enabled and a logGroupName exists
         .getLogEvents({
           logGroupName,
           logStreamName,
@@ -155,7 +155,7 @@ async function waitForBuildEndTime(
   return waitForBuildEndTime(
     sdk,
     current,
-    { updateInterval, updateBackOff },
+    { updateInterval, updateBackOff, hideCloudwatchLogs },
     seqEmptyLogs,
     totalEvents,
     throttleCount,
@@ -210,6 +210,9 @@ function githubInputs() {
       10
     ) * 1000;
 
+  const hideCloudwatchLogs =
+    core.getInput("hide-cloudwatch-logs", { required: false }) || undefined;
+
   return {
     projectName,
     owner,
@@ -223,6 +226,7 @@ function githubInputs() {
     updateInterval,
     updateBackOff,
     disableSourceOverride,
+    hideCloudwatchLogs,
   };
 }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-actions/aws-codebuild-run-build/pull/85

*Description of changes:* hide cloud watch logs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

