### PR TITLE
Allow users to supress CloudWatch Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,14 @@ The only required input is `project-name`.
    When API rate-limiting is hit the back-off time, augmented with jitter, will be
    added to the next update interval.
    E.g. with update interval of 30 and back-off time of 15, upon hitting the rate-limit
-   the next interval for the update call will be 30 + random_between(0, 15 _ 2 \*\* 0))
+   the next interval for the update call will be 30 + random*between(0, 15 * 2 \*\* 0))
    seconds and if the rate-limit is hit again the next interval will be
-   30 + random_between(0, 15 _ 2 \*\* 1) and so on.
+   30 + random*between(0, 15 * 2 \*\* 1) and so on.
 
    The default value is 15.
+
+1. **hide-cloudwatch-logs** (optional) :
+   Set to `true` if you do not want CloudWatch logs to be streamed to GitHub Action.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The only required input is `project-name`.
    The default value is 15.
 
 1. **hide-cloudwatch-logs** (optional) :
-   Set to `true` if you do not want CloudWatch logs to be streamed to GitHub Action.
+   Set to `true` if you do not want CloudWatch Logs to be streamed to GitHub Action.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
   disable-source-override:
     description: 'Set to `true` if you want do disable source repo override'
     required: false
+  hide-cloudwatch-logs:
+    description: 'Set to `true` to prevent the CloudWatch logs from streaming the output to GitHub'
+    required: false
+    default: false
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,6 @@ inputs:
   hide-cloudwatch-logs:
     description: 'Set to `true` to prevent the CloudWatch logs from streaming the output to GitHub'
     required: false
-    default: false
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'

--- a/code-build.js
+++ b/code-build.js
@@ -22,10 +22,10 @@ function runBuild() {
 
   const inputs = githubInputs();
 
-  const config = (({ updateInterval, updateBackOff, hideCloudwatchLogs }) => ({
+  const config = (({ updateInterval, updateBackOff, hideCloudWatchLogs }) => ({
     updateInterval,
     updateBackOff,
-    hideCloudwatchLogs,
+    hideCloudWatchLogs,
   }))(inputs);
 
   // Get input options for startBuild
@@ -45,7 +45,7 @@ async function build(sdk, params, config) {
 async function waitForBuildEndTime(
   sdk,
   { id, logs },
-  { updateInterval, updateBackOff, hideCloudwatchLogs },
+  { updateInterval, updateBackOff, hideCloudWatchLogs },
   seqEmptyLogs,
   totalEvents,
   throttleCount,
@@ -66,9 +66,9 @@ async function waitForBuildEndTime(
   // Check the state
   const [batch, cloudWatch = {}] = await Promise.all([
     codeBuild.batchGetBuilds({ ids: [id] }).promise(),
-    !hideCloudwatchLogs &&
+    !hideCloudWatchLogs &&
       logGroupName &&
-      cloudWatchLogs // only make the call if hideCloudwatchLogs is not enabled and a logGroupName exists
+      cloudWatchLogs // only make the call if hideCloudWatchLogs is not enabled and a logGroupName exists
         .getLogEvents({
           logGroupName,
           logStreamName,
@@ -155,7 +155,7 @@ async function waitForBuildEndTime(
   return waitForBuildEndTime(
     sdk,
     current,
-    { updateInterval, updateBackOff, hideCloudwatchLogs },
+    { updateInterval, updateBackOff, hideCloudWatchLogs },
     seqEmptyLogs,
     totalEvents,
     throttleCount,
@@ -210,8 +210,8 @@ function githubInputs() {
       10
     ) * 1000;
 
-  const hideCloudwatchLogs =
-    core.getInput("hide-cloudwatch-logs", { required: false }) || undefined;
+  const hideCloudWatchLogs =
+    core.getInput("hide-cloudwatch-logs", { required: false }) === "true";
 
   return {
     projectName,
@@ -226,7 +226,7 @@ function githubInputs() {
     updateInterval,
     updateBackOff,
     disableSourceOverride,
-    hideCloudwatchLogs,
+    hideCloudWatchLogs,
   };
 }
 

--- a/code-build.js
+++ b/code-build.js
@@ -22,9 +22,10 @@ function runBuild() {
 
   const inputs = githubInputs();
 
-  const config = (({ updateInterval, updateBackOff }) => ({
+  const config = (({ updateInterval, updateBackOff, hideCloudwatchLogs }) => ({
     updateInterval,
     updateBackOff,
+    hideCloudwatchLogs,
   }))(inputs);
 
   // Get input options for startBuild
@@ -44,7 +45,7 @@ async function build(sdk, params, config) {
 async function waitForBuildEndTime(
   sdk,
   { id, logs },
-  { updateInterval, updateBackOff },
+  { updateInterval, updateBackOff, hideCloudwatchLogs },
   seqEmptyLogs,
   totalEvents,
   throttleCount,
@@ -62,13 +63,12 @@ async function waitForBuildEndTime(
   const { logGroupName, logStreamName } = logName(cloudWatchLogsArn);
 
   let errObject = false;
-
   // Check the state
   const [batch, cloudWatch = {}] = await Promise.all([
     codeBuild.batchGetBuilds({ ids: [id] }).promise(),
-    // The CloudWatchLog _may_ not be set up, only make the call if we have a logGroupName
-    logGroupName &&
-      cloudWatchLogs
+    !hideCloudwatchLogs &&
+      logGroupName &&
+      cloudWatchLogs // only make the call if hideCloudwatchLogs is not enabled and a logGroupName exists
         .getLogEvents({
           logGroupName,
           logStreamName,
@@ -155,7 +155,7 @@ async function waitForBuildEndTime(
   return waitForBuildEndTime(
     sdk,
     current,
-    { updateInterval, updateBackOff },
+    { updateInterval, updateBackOff, hideCloudwatchLogs },
     seqEmptyLogs,
     totalEvents,
     throttleCount,
@@ -210,6 +210,9 @@ function githubInputs() {
       10
     ) * 1000;
 
+  const hideCloudwatchLogs =
+    core.getInput("hide-cloudwatch-logs", { required: false }) || undefined;
+
   return {
     projectName,
     owner,
@@ -223,6 +226,7 @@ function githubInputs() {
     updateInterval,
     updateBackOff,
     disableSourceOverride,
+    hideCloudwatchLogs,
   };
 }
 

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -82,6 +82,7 @@ describe("githubInputs", () => {
       .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
+    expect(test).to.haveOwnProperty("hideCloudWatchLogs").and.to.equal(false);
   });
 
   it("a project name is required.", () => {
@@ -170,6 +171,7 @@ describe("githubInputs", () => {
       "No source version could be evaluated."
     );
   });
+
   it("can handle configuring update call-rate", () => {
     process.env[`INPUT_PROJECT-NAME`] = projectName;
     process.env[`INPUT_UPDATE-INTERVAL`] = `${updateInterval}`;
@@ -187,6 +189,19 @@ describe("githubInputs", () => {
     expect(test)
       .to.haveOwnProperty("updateBackOff")
       .and.to.equal(updateBackOff * 1000);
+  });
+
+  it("can hide cloudwatch logs when the parameter is set to true", () => {
+    // This is how GITHUB injects its input values.
+    // It would be nice if there was an easy way to test this...
+    process.env[`INPUT_PROJECT-NAME`] = projectName;
+    process.env[`INPUT_HIDE-CLOUDWATCH-LOGS`] = "true";
+    process.env[`GITHUB_REPOSITORY`] = repoInfo;
+    process.env[`GITHUB_SHA`] = sha;
+
+    const test = githubInputs();
+
+    expect(test).to.haveOwnProperty("hideCloudWatchLogs").and.to.equal(true);
   });
 });
 


### PR DESCRIPTION
- Update the hide-cloudwatch-logs feature
- add some tests

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

