### PR TITLE
Updating README with an example of doing an inline definition for buildspec-override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,42 @@ The only required input is `project-name`.
    The location (in this repository) of the [buildspec file][codebuild buildspec]
    that CodeBuild requires.
    By default, the action uses the buildspec file location
-   that you configured in the CodeBuild project.
+   that you configured in the CodeBuild project. 
+  
+   Alternatively, you can pass in an inline buildspec definition like so:
+
+   ```
+   - name: Run CodeBuild
+       uses: aws-actions/aws-codebuild-run-build@v1
+       with:
+          project-name: my-codebuild-job
+          disable-source-override: true
+          buildspec-override:   |
+            version: 0.2
+            phases:
+              install:
+                runtime-versions:
+                  nodejs: 16
+                commands:
+                  - npm install -g typescript
+                  - npm install
+              pre_build:
+                commands:
+                  - echo Installing source NPM dependencies...
+              build:
+                commands:
+                  - echo Build started on `date`
+                  - tsc
+                  - npm prune --production
+                post_build:
+                  commands:
+                    - echo Build completed on `date`  
+            artifacts:
+              type: zip
+              files:
+                - package.json
+                - package-lock.json
+   ```
 1. **compute-type-override** (optional) :
    The name of a compute type for this build that overrides the one specified
    in the build project.
@@ -201,7 +236,7 @@ this will overwrite them.
   uses: aws-actions/aws-codebuild-run-build@v1
   with:
     project-name: CodeBuildProjectName
-    buildspec-override: path/to/buildspec.yaml
+    buildspec-override: path/to/buildspec.yaml or inline buildspec definition
     compute-type-override: compute-type
     environment-type-override: environment-type
     image-override: ecr-image-uri

--- a/README.md
+++ b/README.md
@@ -27,35 +27,35 @@ The only required input is `project-name`.
 
    ```
    - name: Run CodeBuild
-       uses: aws-actions/aws-codebuild-run-build@v1
-       with:
-          project-name: my-codebuild-job
-          disable-source-override: true
-          buildspec-override:   |
-            version: 0.2
-            phases:
-              install:
-                runtime-versions:
-                  nodejs: 16
-                commands:
-                  - npm install -g typescript
-                  - npm install
-              pre_build:
-                commands:
-                  - echo Installing source NPM dependencies...
-              build:
-                commands:
-                  - echo Build started on `date`
-                  - tsc
-                  - npm prune --production
-                post_build:
-                  commands:
-                    - echo Build completed on `date`  
-            artifacts:
-              type: zip
-              files:
-                - package.json
-                - package-lock.json
+     uses: aws-actions/aws-codebuild-run-build@v1
+     with:
+       project-name: my-codebuild-job
+       disable-source-override: true
+       buildspec-override:   |
+         version: 0.2
+         phases:
+           install:
+             runtime-versions:
+               nodejs: 16
+             commands:
+               - npm install -g typescript
+               - npm install
+           pre_build:
+             commands:
+               - echo Installing source NPM dependencies...
+           build:
+             commands:
+               - echo Build started on `date`
+               - tsc
+               - npm prune --production
+             post_build:
+               commands:
+                 - echo Build completed on `date`  
+         artifacts:
+           type: zip
+           files:
+             - package.json
+             - package-lock.json
    ```
 1. **compute-type-override** (optional) :
    The name of a compute type for this build that overrides the one specified


### PR DESCRIPTION
*Issue #, if available:* 
N/A

*Description of changes:*

Last night at the time of writing, I noticed that the codebuild api allows users to pass in an inline definition of a buildspec file for buildspec-override.  In a project, I tried that out with this action and it worked. Figured it would be worth documenting for others to use if their use case calls for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

