### PR TITLE
Disabled GITHUB Envs being passed to Codebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ The only required input is `project-name`.
 1. **hide-cloudwatch-logs** (optional) :
    Set to `true` if you do not want CloudWatch Logs to be streamed to GitHub Action.
 
+1. **disable-github-env-vars** (optional) :
+   Set to `true` if you want do disable github environment variables in codebuild.
+
 ### Outputs
 
 1. **aws-build-id** : The CodeBuild build ID of the build that the action ran.

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   hide-cloudwatch-logs:
     description: 'Set to `true` to prevent the CloudWatch logs from streaming the output to GitHub'
     required: false
+  disable-github-env-vars:
+    description: 'Set to `true` if you want do disable github environment variables in codebuild'
+    required: false
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'

--- a/code-build.js
+++ b/code-build.js
@@ -167,6 +167,8 @@ function githubInputs() {
   const projectName = core.getInput("project-name", { required: true });
   const disableSourceOverride =
     core.getInput("disable-source-override", { required: false }) === "true";
+  const disableGithubEnvVars =
+    core.getInput("disable-github-env-vars", { required: false }) === "true";
   const { owner, repo } = github.context.repo;
   const { payload } = github.context;
   // The github.context.sha is evaluated on import.
@@ -227,6 +229,7 @@ function githubInputs() {
     updateBackOff,
     disableSourceOverride,
     hideCloudWatchLogs,
+    disableGithubEnvVars,
   };
 }
 
@@ -242,6 +245,7 @@ function inputs2Parameters(inputs) {
     imageOverride,
     envPassthrough = [],
     disableSourceOverride,
+    disableGithubEnvVars,
   } = inputs;
 
   const sourceOverride = !disableSourceOverride
@@ -254,7 +258,9 @@ function inputs2Parameters(inputs) {
 
   const environmentVariablesOverride = Object.entries(process.env)
     .filter(
-      ([key]) => key.startsWith("GITHUB_") || envPassthrough.includes(key)
+      ([key]) =>
+        (!disableGithubEnvVars && key.startsWith("GITHUB_")) ||
+        envPassthrough.includes(key)
     )
     .map(([name, value]) => ({ name, value, type: "PLAINTEXT" }));
 

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -85,6 +85,7 @@ describe("githubInputs", () => {
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
     expect(test).to.haveOwnProperty("hideCloudWatchLogs").and.to.equal(false);
+    expect(test).to.haveOwnProperty("disableGithubEnvVars").and.to.equal(false);
   });
 
   it("a project name is required.", () => {
@@ -399,6 +400,29 @@ describe("inputs2Parameters", () => {
     expect(test).to.not.haveOwnProperty("sourceTypeOverride");
     expect(test).to.not.haveOwnProperty("sourceLocationOverride");
     expect(test).to.not.haveOwnProperty("sourceVersion");
+  });
+
+  it("can process disable-github-env-vars", () => {
+    process.env[`GITHUB_REPOSITORY`] = repoInfo;
+    process.env[`GITHUB_SHA`] = sha;
+
+    const test = inputs2Parameters({
+      projectName,
+      sourceVersion: sha,
+      owner: "owner",
+      repo: "repo",
+      disableGithubEnvVars: true,
+    });
+
+    const [repoEnv] = test.environmentVariablesOverride.filter(
+      ({ name }) => name === "GITHUB_REPOSITORY"
+    );
+    expect(repoEnv).to.equal(undefined);
+
+    const [shaEnv] = test.environmentVariablesOverride.filter(
+      ({ name }) => name === "GITHUB_SHA"
+    );
+    expect(shaEnv).to.equal(undefined);
   });
 });
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-actions/aws-codebuild-run-build/issues/127#issuecomment-1561388331

*Description of changes:*
Disabled GITHUB Envs being passed to Codebuild

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

