### PR TITLE
allow artifacts type to be overridden

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   disable-github-env-vars:
     description: 'Set to `true` if you want do disable github environment variables in codebuild'
     required: false
+  artifacts-type-override:
+      description: 'The type of build output artifact'
+      required: false
 outputs:
   aws-build-id:
     description: 'The AWS CodeBuild Build ID for this build.'

--- a/code-build.js
+++ b/code-build.js
@@ -173,8 +173,9 @@ function githubInputs() {
     core.getInput("compute-type-override", { required: false }) || undefined;
 
   const environmentTypeOverride =
-    core.getInput("environment-type-override", { required: false }) || undefined;
-  const imageOverride = 
+    core.getInput("environment-type-override", { required: false }) ||
+    undefined;
+  const imageOverride =
     core.getInput("image-override", { required: false }) || undefined;
 
   const envPassthrough = core
@@ -211,6 +212,7 @@ function inputs2Parameters(inputs) {
 
   const sourceTypeOverride = "GITHUB";
   const sourceLocationOverride = `https://github.com/${owner}/${repo}.git`;
+  const artifactsOverride = { type: "NO_ARTIFACTS" };
 
   const environmentVariablesOverride = Object.entries(process.env)
     .filter(
@@ -225,6 +227,7 @@ function inputs2Parameters(inputs) {
     sourceVersion,
     sourceTypeOverride,
     sourceLocationOverride,
+    artifactsOverride,
     buildspecOverride,
     computeTypeOverride,
     environmentTypeOverride,

--- a/code-build.js
+++ b/code-build.js
@@ -222,6 +222,9 @@ function githubInputs() {
   const disableGithubEnvVars =
     core.getInput("disable-github-env-vars", { required: false }) === "true";
 
+  const artifactsTypeOverride =
+    core.getInput("artifacts-type-override", { required: false }) || undefined;
+
   return {
     projectName,
     owner,
@@ -238,6 +241,7 @@ function githubInputs() {
     disableSourceOverride,
     hideCloudWatchLogs,
     disableGithubEnvVars,
+    artifactsTypeOverride,
   };
 }
 
@@ -255,6 +259,7 @@ function inputs2Parameters(inputs) {
     envPassthrough = [],
     disableSourceOverride,
     disableGithubEnvVars,
+    artifactsTypeOverride,
   } = inputs;
 
   const sourceOverride = !disableSourceOverride
@@ -265,7 +270,13 @@ function inputs2Parameters(inputs) {
       }
     : {};
 
-  const artifactsOverride = { type: "NO_ARTIFACTS" };
+  const artifactsOverride = artifactsTypeOverride
+    ? {
+        artifactsOverride: {
+          type: artifactsTypeOverride,
+        },
+      }
+    : {};
 
   const environmentVariablesOverride = Object.entries(process.env)
     .filter(
@@ -281,7 +292,7 @@ function inputs2Parameters(inputs) {
     projectName,
     ...sourceOverride,
     buildspecOverride,
-    artifactsOverride,
+    ...artifactsOverride,
     computeTypeOverride,
     environmentTypeOverride,
     imageOverride,

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -245,10 +245,6 @@ describe("inputs2Parameters", () => {
       .to.haveOwnProperty("sourceLocationOverride")
       .and.to.equal(`https://github.com/owner/repo.git`);
     expect(test)
-      .to.haveOwnProperty("artifactsOverride")
-      .that.has.property("type")
-      .that.equals("NO_ARTIFACTS");
-    expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
     expect(test)
@@ -300,6 +296,7 @@ describe("inputs2Parameters", () => {
       imageOverride:
         "111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo",
       imagePullCredentialsTypeOverride: "CODEBUILD",
+      artifactsTypeOverride: "NO_ARTIFACTS",
     });
     expect(test).to.haveOwnProperty("projectName").and.to.equal(projectName);
     expect(test).to.haveOwnProperty("sourceVersion").and.to.equal(sha);

--- a/test/code-build-test.js
+++ b/test/code-build-test.js
@@ -71,8 +71,12 @@ describe("githubInputs", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("computeTypeOverride").and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("environmentTypeOverride").and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("computeTypeOverride")
+      .and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("environmentTypeOverride")
+      .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
   });
@@ -88,7 +92,7 @@ describe("githubInputs", () => {
     process.env[`GITHUB_REPOSITORY`] = repoInfo;
     process.env[`GITHUB_SHA`] = sha;
 
-    process.env[`INPUT_ENV-VARS-FOR-CODEBUILD`] = `one, two 
+    process.env[`INPUT_ENV-VARS-FOR-CODEBUILD`] = `one, two
     , three,
     four    `;
 
@@ -123,8 +127,12 @@ describe("githubInputs", () => {
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("computeTypeOverride").and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("environmentTypeOverride").and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("computeTypeOverride")
+      .and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("environmentTypeOverride")
+      .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
     expect(test).to.haveOwnProperty("envPassthrough").and.to.deep.equal([]);
   });
@@ -177,10 +185,18 @@ describe("inputs2Parameters", () => {
       .to.haveOwnProperty("sourceLocationOverride")
       .and.to.equal(`https://github.com/owner/repo.git`);
     expect(test)
+      .to.haveOwnProperty("artifactsOverride")
+      .that.has.property("type")
+      .that.equals("NO_ARTIFACTS");
+    expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("computeTypeOverride").and.to.equal(undefined);
-    expect(test).to.haveOwnProperty("environmentTypeOverride").and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("computeTypeOverride")
+      .and.to.equal(undefined);
+    expect(test)
+      .to.haveOwnProperty("environmentTypeOverride")
+      .and.to.equal(undefined);
     expect(test).to.haveOwnProperty("imageOverride").and.to.equal(undefined);
 
     // I send everything that starts 'GITHUB_'
@@ -218,7 +234,8 @@ describe("inputs2Parameters", () => {
       repo: "repo",
       computeTypeOverride: "BUILD_GENERAL1_LARGE",
       environmentTypeOverride: "LINUX_CONTAINER",
-      imageOverride: "111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo"
+      imageOverride:
+        "111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo",
     });
     expect(test).to.haveOwnProperty("projectName").and.to.equal(projectName);
     expect(test).to.haveOwnProperty("sourceVersion").and.to.equal(sha);
@@ -228,6 +245,10 @@ describe("inputs2Parameters", () => {
     expect(test)
       .to.haveOwnProperty("sourceLocationOverride")
       .and.to.equal(`https://github.com/owner/repo.git`);
+    expect(test)
+      .to.haveOwnProperty("artifactsOverride")
+      .that.has.property("type")
+      .that.equals("NO_ARTIFACTS");
     expect(test)
       .to.haveOwnProperty("buildspecOverride")
       .and.to.equal(undefined);
@@ -239,7 +260,9 @@ describe("inputs2Parameters", () => {
       .and.to.equal(`LINUX_CONTAINER`);
     expect(test)
       .to.haveOwnProperty("imageOverride")
-      .and.to.equal(`111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo`);
+      .and.to.equal(
+        `111122223333.dkr.ecr.us-west-2.amazonaws.com/codebuild-docker-repo`
+      );
 
     // I send everything that starts 'GITHUB_'
     expect(test)
@@ -270,7 +293,7 @@ describe("inputs2Parameters", () => {
     process.env[`GITHUB_REPOSITORY`] = repoInfo;
     process.env[`GITHUB_SHA`] = sha;
 
-    process.env[`INPUT_ENV-VARS-FOR-CODEBUILD`] = `one, two 
+    process.env[`INPUT_ENV-VARS-FOR-CODEBUILD`] = `one, two
     , three,
     four    `;
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-actions/aws-codebuild-run-build/issues/114

*Description of changes:*
add non required `artifacts-type-override` to specify codebuild use a different or no artifaction location than it might be in a code pipeline run

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

