### PR TITLE
Use correct option name for env-vars-for-codebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Otherwise, it fails.
 
 In the call to StartBuild, we pass in all
 `GITHUB_` [environment variables][github environment variables] in the GitHub Actions environment,
-plus any environment variables that you specified in the `env-passthrough` input value.
+plus any environment variables that you specified in the `env-vars-for-codebuild` input value.
 
 By default, regardless of the project configuration in CodeBuild or GitHub Actions,
 we always pass the following parameters and values to CodeBuild in the StartBuild API call.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update documentation to reflect changes from https://github.com/aws-actions/aws-codebuild-run-build/pull/24

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

