### PR TITLE
Account for pull_request_target trigger when getting the sourceVersion

### DIFF
--- a/code-build.js
+++ b/code-build.js
@@ -175,8 +175,11 @@ function githubInputs() {
   // There is a complexity here because for pull request
   // the GITHUB_SHA value is NOT the correct value.
   // See: https://github.com/aws-actions/aws-codebuild-run-build/issues/36
+
+  const eventName = process.env[`GITHUB_EVENT_NAME`];
+  const isPullRequest = ["pull_request", "pull_request_target"].includes(eventName);
   const sourceVersion =
-    process.env[`GITHUB_EVENT_NAME`] === "pull_request"
+      isPullRequest
       ? (((payload || {}).pull_request || {}).head || {}).sha
       : process.env[`GITHUB_SHA`];
 


### PR DESCRIPTION
*Issue #, if available:*

Fully addresses https://github.com/aws-actions/aws-codebuild-run-build/issues/36 and https://github.com/aws-actions/aws-codebuild-run-build/pull/40

*Description of changes:*

The change in https://github.com/aws-actions/aws-codebuild-run-build/pull/40 introduced special treatment for `pull_request` event by fetching the head commit of the pull request but does not take into account the [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event, which is also a pull request and has identical context data.  This leads to the event being treated differently and instead of fetching `pull_request.head.sha` it fetches `GITHUB_SHA` from the environment variable. Looks like the `pull_request_target` was introduced on August 2020 according to [this blog post](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/), this was after https://github.com/aws-actions/aws-codebuild-run-build/pull/40.

The proposed change in this PR accounts for the two possible events that will be triggered by a pull request - `pull_request` and `pull_request_target`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

