### PR TITLE
feat: Add sourceVersion override

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The only required input is `project-name`.
 1. **disable-source-override** (optional) :
    Set to `true` if you want to disable providing `sourceVersion`,
    `sourceTypeOverride` and `sourceLocationOverride` to CodeBuild.
+1. **source-version-override** (optional) :
+   The source version that overrides the `sourceVersion` provided to Codebuild.
 1. **env-vars-for-codebuild** (optional) :
    A comma-separated list of the names of environment variables
    that the action passes from GitHub Actions to CodeBuild.

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   disable-source-override:
     description: 'Set to `true` if you want do disable source repo override'
     required: false
+  source-version-override:
+    description: 'The source version that overrides the sourceVersion provided to Codebuild.'
+    required: false
   hide-cloudwatch-logs:
     description: 'Set to `true` to prevent the CloudWatch logs from streaming the output to GitHub'
     required: false

--- a/code-build.js
+++ b/code-build.js
@@ -176,9 +176,10 @@ function githubInputs() {
   // the GITHUB_SHA value is NOT the correct value.
   // See: https://github.com/aws-actions/aws-codebuild-run-build/issues/36
   const sourceVersion =
-    process.env[`GITHUB_EVENT_NAME`] === "pull_request"
+    core.getInput("source-version-override", { required: false }) || 
+    (process.env[`GITHUB_EVENT_NAME`] === "pull_request"
       ? (((payload || {}).pull_request || {}).head || {}).sha
-      : process.env[`GITHUB_SHA`];
+      : process.env[`GITHUB_SHA`]);
 
   assert(sourceVersion, "No source version could be evaluated.");
   const buildspecOverride =


### PR DESCRIPTION
*Issue #, if available:* 
#132

*Description of changes:*
Add optional `source-version-override` to allow running CodeBuild from different `sourceVersion` than `aws-codebuild-run-build` action.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

