### PR TITLE
Use Node20 for building

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
-      - name: Use node.js 16.x
-        uses: actions/setup-node@v3
+      - name: Use node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - name: NPM Install
         run: npm ci
       - name: Check Format


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Getting the following warnings when using this action: `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: aws-actions/aws-codebuild-run-build@v1.`

* Use NodeJS 20.x when building a package
* Use latest `actions/checkout` and `actions/setup-node`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

