### PR TITLE
Add an introduction of the new self-hosted-runner option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ that are impossible, difficult, or simply expensive
 to access from GitHub's hosted job runners
 but are easy or cheap to access from CodeBuild.
 
+### Related features
+🆕 [**Self-Hosted Runner in CodeBuild:**](https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html) you can use CodeBuild to run ephemeral, self-hosted GitHub Actions runners. This allows you to leverage GitHub workflow ecosystem, while granting your workflow jobs native integration with AWS.
+
 ## Credentials and Permissions
 
 In order for the action to run your CodeBuild project,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* CodeBuild recently launched another integration option for Github Action, so introducing this feature as a related feature in README 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

