### PR TITLE
document `codebuild:StopBuild` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ See the [GitHub Secrets docs][github secrets access] for more information.**
 The credentials that you provide need to have the following permissions:
 
 - `codebuild:StartBuild`
+- `codebuild:StopBuild`
 - `codebuild:BatchGetBuilds`
 - `logs:GetLogEvents`
 
@@ -204,7 +205,7 @@ For example:
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": ["codebuild:StartBuild", "codebuild:BatchGetBuilds"],
+      "Action": ["codebuild:StartBuild", "codebuild:StopBuild", "codebuild:BatchGetBuilds"],
       "Resource": ["arn:aws:codebuild:REGION:ACCOUNT_ID:project/PROJECT_NAME"]
     },
     {


### PR DESCRIPTION
Adds documentation of the `codebuild:StopBuild` API that this action will invoke when an Actions job is canceled:

https://github.com/aws-actions/aws-codebuild-run-build/blob/709330557ef351db2ee400ec41f672ea1734c255/code-build.js#L61

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

