### PR TITLE
Add support to running local action against self-hosted GitHub remotes

### DIFF
--- a/local.js
+++ b/local.js
@@ -7,6 +7,7 @@ const cp = require("child_process");
 const cb = require("./code-build");
 const assert = require("assert");
 const yargs = require("yargs");
+const { log } = require("console");
 
 const {
   projectName,
@@ -117,10 +118,10 @@ function deleteBranch(remote, branchName) {
 }
 
 function githubInfo(remote) {
-  const gitHubSSH = "git@github.com:";
-  const gitHubHTTPS = "https://github.com/";
+  const repoSSH = "git@";
+  const repoHTTPS = "https://";
   /* Expecting to match something like:
-   * 'fork    git@github.com:seebees/aws-codebuild-run-build.git (push)'
+   * 'fork    git@<hostname>:seebees/aws-codebuild-run-build.git (push)'
    * Which is the output of `git remote -v`
    */
   const remoteMatch = new RegExp(`^${remote}.*\\(push\\)$`);
@@ -137,11 +138,13 @@ function githubInfo(remote) {
     .filter((line) => line.trim().match(remoteMatch));
   assert(gitRemote, `No remote found named ${remote}`);
   const [, url] = gitRemote.split(/[\t ]/);
-  if (url.startsWith(gitHubHTTPS)) {
-    const [owner, repo] = url.slice(gitHubHTTPS.length, -4).split("/");
+  if (url.startsWith(repoHTTPS)) {
+    const [owner, repo] = url.slice(repoHTTPS.length, -4).split("/").slice(-2);
+    console.log(`owner: ${owner}, repo: ${repo}`);
     return { owner, repo };
-  } else if (url.startsWith(gitHubSSH)) {
-    const [owner, repo] = url.slice(gitHubSSH.length, -4).split("/");
+  } else if (url.startsWith(repoSSH)) {
+    const [owner, repo] = url.slice(repoSSH.length, -4).split(':').pop().split("/");
+    console.log(`owner: ${owner}, repo: ${repo}`);
     return { owner, repo };
   } else {
     throw new Error(`Unsupported format: ${url}`);

--- a/local.js
+++ b/local.js
@@ -138,15 +138,21 @@ function githubInfo(remote) {
     .filter((line) => line.trim().match(remoteMatch));
   assert(gitRemote, `No remote found named ${remote}`);
   const [, url] = gitRemote.split(/[\t ]/);
+  const url_path_elements = [];
+  
   if (url.startsWith(repoHTTPS)) {
-    const [owner, repo] = url.slice(repoHTTPS.length, -4).split("/").slice(-2);
-    console.log(`owner: ${owner}, repo: ${repo}`);
-    return { owner, repo };
+    url_path_elements.push(...url.slice(repoHTTPS.length, -4).split("/"));
   } else if (url.startsWith(repoSSH)) {
-    const [owner, repo] = url.slice(repoSSH.length, -4).split(':').pop().split("/");
-    console.log(`owner: ${owner}, repo: ${repo}`);
-    return { owner, repo };
+    url_path_elements.push(...url.slice(repoSSH.length, -4).split(':').pop().split("/"));
   } else {
-    throw new Error(`Unsupported format: ${url}`);
+    throw new Error(`Unsupported format - not a valid HTTPS or SSH URL: ${url}`);
   }
+  
+  if (url_path_elements.length < 2) {
+    throw new Error(`Unsupported format - could not find owner and repo in path: ${url}`);
+  }
+
+  // The last two elements of any valid git remote URL path should be the owner and repo.
+  const {owner, repo} = url_path_elements.slice(-2);
+  return { owner, repo };
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

This removes the restriction that the remote origin contains "github.com", so that users of self-hosted GitHub Enterprise servers can use the npm action.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

