### PR TITLE
document workaround for npm 404 error on local

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ you must first `git checkout` the commit that you want to test.
 npx @aws-actions/codebuild-run-build -p ProjectName -r remoteName
 ```
 
+Note: If the above command returns a 404 error, you might need to add the package manually.
+```
+npm install git@github.com:aws-actions/aws-codebuild-run-build.git
+# OR
+yard add git@github.com:aws-actions/aws-codebuild-run-build.git
+```
+
 This will use whatever commit you have checked out
 and push to a temporary branch in the specified remote.
 Then kick off the build


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-actions/aws-codebuild-run-build/issues/170

*Description of changes:* Updated README.md file to document workaround for npm 404 error during local testing. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

